### PR TITLE
feat(ui): improve window behavior, context menus and status/wiki visibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ This keeps core runtime behavior synchronized across both variants.
 - multi-device Git workflow: `project-tkinter/GIT_WORKFLOW_PL.md`
 - support info: `SUPPORT_PL.md`
 - docs index (Wiki/Pages ready): `docs/README.md`
+- online docs portal: `https://piotrgrechuta-web.github.io/epu2pl/`
+- where progress/UI/Wiki are visible: `docs/08-Status-UI-i-Wiki.md`
 
 ## Support
 - Sponsor: https://github.com/sponsors/piotrgrechuta-web

--- a/README.pl.md
+++ b/README.pl.md
@@ -93,6 +93,8 @@ Dzieki temu zachowanie logiki runtime jest synchronizowane miedzy wariantami.
 - manual uzytkownika Tkinter (PL): `project-tkinter/MANUAL_PL.md`
 - workflow Git na wielu komputerach: `project-tkinter/GIT_WORKFLOW_PL.md`
 - informacje o wsparciu: `SUPPORT_PL.md`
+- portal dokumentacji online: `https://piotrgrechuta-web.github.io/epu2pl/`
+- gdzie widac postep/UI/Wiki: `docs/08-Status-UI-i-Wiki.md`
 
 ## Wsparcie
 - Sponsor: https://github.com/sponsors/piotrgrechuta-web

--- a/docs/06-Troubleshooting.md
+++ b/docs/06-Troubleshooting.md
@@ -66,3 +66,24 @@ Sprawdz:
 4. opisz oczekiwane vs rzeczywiste zachowanie.
 
 To radykalnie skraca czas diagnozy.
+
+## 6.8. Wiki przekierowuje na strone repo (302)
+
+Objaw:
+- `https://github.com/<owner>/<repo>/wiki` wraca do strony glownej repo,
+- `git ls-remote https://github.com/<owner>/<repo>.wiki.git` zwraca blad.
+
+Co zrobic:
+1. Wejdz w `Settings -> General -> Features` i potwierdz, ze `Wiki` jest wlaczone.
+2. Wylacz i wlacz `Wiki` ponownie (czasem backend nie inicjalizuje sie poprawnie za pierwszym razem).
+3. Otworz zakladke `Wiki` i utworz pierwsza strone (np. `Home`) - to inicjalizuje repozytorium `*.wiki.git`.
+4. Po inicjalizacji sprawdz:
+
+```powershell
+gh api repos/<owner>/<repo> --jq "{has_wiki,default_branch:.default_branch}"
+git ls-remote https://github.com/<owner>/<repo>.wiki.git
+```
+
+Fallback:
+- jezeli backend Wiki nadal nie odpowiada, trzymaj dokumentacje w `docs/` i publikuj przez GitHub Pages:
+  - `https://piotrgrechuta-web.github.io/epu2pl/`

--- a/docs/08-Status-UI-i-Wiki.md
+++ b/docs/08-Status-UI-i-Wiki.md
@@ -1,0 +1,55 @@
+# 08. Status UI i Wiki/Pages
+
+## Cel
+
+Ta sekcja odpowiada na 3 praktyczne pytania:
+1. gdzie na ekranie widac postep projektu,
+2. gdzie jest dokumentacja (Wiki/Pages),
+3. jakie poprawki UX zostaly wdrozone.
+
+## Gdzie widac postep projektu (Tkinter)
+
+Ekran: sekcja `Projekt i profile` (lewy panel, u gory).
+
+Najwazniejsze elementy:
+- licznik statusow wszystkich projektow: `idle/pending/running/error`,
+- lista statusu projektow z podsumowaniem ksiazki i etapow,
+- format wpisu:
+  - `ks=<book> | T:<done>/<total> <status> | R:<done>/<total> <status> | -> <next_action>`.
+
+Dodatkowo:
+- `Historia runow` pokazuje ostatnie uruchomienia aktywnego projektu,
+- sekcja `Uruchomienie` pokazuje biezacy status procesu i postep.
+
+## Gdzie widac postep projektu (Web Desktop)
+
+Ekran: gora aplikacji web-desktop (`project-web-desktop`):
+- rozwijana lista projektu zawiera skrot statusu i podsumowanie etapow,
+- pole `Podsumowanie projektu` pokazuje ksiazke + T/R + nastepna akcje.
+
+Format jest spojny z wariantem Tkinter:
+- `ks=<book> | T:<done>/<total> <status> | R:<done>/<total> <status> | -> <next_action>`.
+
+## Poprawki UX wdrozone w aplikacjach
+
+Wariant Tkinter (`start.py`, `start_horizon.py`, `studio_suite.py`):
+- glowne okno i okna narzedzi startuja w trybie maksymalnym (z dynamicznymi granicami),
+- po zmniejszeniu okna dostepne sa paski przewijania (pion/poziom),
+- menu kontekstowe pod prawym przyciskiem myszy w polach edycyjnych:
+  - `Cofnij`, `Ponow`, `Wytnij`, `Kopiuj`, `Wklej`, `Usun`,
+  - `Zaznacz wszystko`, `Wyczysc pole`.
+
+Wariant Web Desktop (`desktop/main.js`, `desktop/renderer/styles.css`):
+- okno Electron startuje na rozmiarze dopasowanym do ekranu i maksymalizuje sie po starcie,
+- layout ma minimalne szerokosci + `overflow`, wiec po pomniejszeniu sa paski przewijania,
+- menu kontekstowe pod prawym klawiszem (undo/redo/cut/copy/paste/delete/select all + link actions).
+
+## Gdzie jest Wiki / Pages
+
+Aktualny punkt wejscia dokumentacji:
+- GitHub Pages: `https://piotrgrechuta-web.github.io/epu2pl/`
+- Repo docs: `docs/`
+
+Wiki GitHub (`/wiki`) moze wymagac inicjalizacji backendu.
+Jesli `/wiki` przekierowuje na strone repo, patrz:
+- `06-Troubleshooting.md`, sekcja `6.8`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Uklad jest przygotowany tak, aby mozna go:
 5. [CI/CD i jakosc](05-CI-CD-i-Jakosc.md)
 6. [Troubleshooting](06-Troubleshooting.md)
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
+8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
 
 ## Dokumenty zrodlowe
 
@@ -29,3 +30,4 @@ Uklad jest przygotowany tak, aby mozna go:
 - Branch protection: aktywna na `master` i `ep2pl`
 - Required checks: `python-checks`, `desktop-manifest-check`, `validate-pr-body`
 - PR template: wymusza wypelnione sekcje i checkliste
+- Dokumentacja online (GitHub Pages): `https://piotrgrechuta-web.github.io/epu2pl/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ To jest strona startowa dla GitHub Pages (`/docs`).
 5. [CI/CD i jakosc](05-CI-CD-i-Jakosc.md)
 6. [Troubleshooting](06-Troubleshooting.md)
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
+8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
 
 ## Zrodla
 

--- a/project-tkinter/start.py
+++ b/project-tkinter/start.py
@@ -143,8 +143,6 @@ class TranslatorGUI:
     def __init__(self, root: tk.Tk) -> None:
         self.root = root
         self.root.title(APP_TITLE)
-        self.root.geometry("1200x820")
-        self.root.minsize(1000, 700)
 
         self.workdir = Path(__file__).resolve().parent
         self.events_log_path = self.workdir / "events" / "app_events.jsonl"
@@ -175,10 +173,17 @@ class TranslatorGUI:
         self._tooltips: List[Any] = []
         self.tooltip_mode = mode_raw
         self._projects_refresh_seq = 0
+        self._root_scroll_canvas: Optional[tk.Canvas] = None
+        self._root_scroll_window: Optional[int] = None
+        self._root_scroll_frame: Optional[ttk.Frame] = None
+        self._context_menu: Optional[tk.Menu] = None
+        self._context_target: Optional[tk.Misc] = None
 
+        self._configure_main_window()
         self._setup_theme()
         self._build_vars()
         self._build_ui()
+        self._install_context_menu()
         self._install_tooltips()
         self.db.import_legacy_gui_settings(SETTINGS_FILE)
         self._load_defaults()
@@ -209,6 +214,181 @@ class TranslatorGUI:
         style.configure("StatusRun.TLabel", background="#eef3f7", foreground="#b45309", font=("Segoe UI Semibold", 10))
         style.configure("StatusOk.TLabel", background="#eef3f7", foreground="#166534", font=("Segoe UI Semibold", 10))
         style.configure("StatusErr.TLabel", background="#eef3f7", foreground="#b91c1c", font=("Segoe UI Semibold", 10))
+
+    def _configure_main_window(self) -> None:
+        self._configure_window_bounds(self.root, preferred_w=1200, preferred_h=820, min_w=760, min_h=520, maximize=True)
+
+    def _configure_window_bounds(
+        self,
+        win: tk.Misc,
+        *,
+        preferred_w: int,
+        preferred_h: int,
+        min_w: int,
+        min_h: int,
+        maximize: bool = False,
+    ) -> None:
+        screen_w = max(1024, int(self.root.winfo_screenwidth() or 1200))
+        screen_h = max(720, int(self.root.winfo_screenheight() or 820))
+
+        eff_min_w = min(max(520, int(screen_w - 120)), max(480, int(min_w)))
+        eff_min_h = min(max(400, int(screen_h - 140)), max(360, int(min_h)))
+        pref_w = min(max(eff_min_w, int(preferred_w)), max(900, screen_w - 40))
+        pref_h = min(max(eff_min_h, int(preferred_h)), max(650, screen_h - 80))
+        x = max(0, (screen_w - pref_w) // 2)
+        y = max(0, (screen_h - pref_h) // 2)
+
+        try:
+            win.geometry(f"{pref_w}x{pref_h}+{x}+{y}")  # type: ignore[attr-defined]
+        except Exception:
+            return
+        try:
+            win.minsize(eff_min_w, eff_min_h)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        if not maximize:
+            return
+        try:
+            win.state("zoomed")  # type: ignore[attr-defined]
+            return
+        except Exception:
+            pass
+        try:
+            win.attributes("-zoomed", True)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+    def _create_scrollable_root(self, *, padding: int = 16) -> ttk.Frame:
+        shell = ttk.Frame(self.root)
+        shell.pack(fill="both", expand=True)
+        shell.columnconfigure(0, weight=1)
+        shell.rowconfigure(0, weight=1)
+
+        bg = str(self.root.cget("bg") or "#eef3f7")
+        canvas = tk.Canvas(shell, highlightthickness=0, borderwidth=0, background=bg)
+        vbar = ttk.Scrollbar(shell, orient="vertical", command=canvas.yview)
+        hbar = ttk.Scrollbar(shell, orient="horizontal", command=canvas.xview)
+        canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)
+
+        canvas.grid(row=0, column=0, sticky="nsew")
+        vbar.grid(row=0, column=1, sticky="ns")
+        hbar.grid(row=1, column=0, sticky="ew")
+
+        frame = ttk.Frame(canvas, padding=padding)
+        window_id = canvas.create_window((0, 0), window=frame, anchor="nw")
+
+        def _sync_layout(_: Optional[tk.Event] = None) -> None:
+            canvas.configure(scrollregion=canvas.bbox("all"))
+            req_w = max(1, int(frame.winfo_reqwidth()))
+            can_w = max(1, int(canvas.winfo_width()))
+            # Keep full-width layout when there is space; allow horizontal scroll when window is too narrow.
+            canvas.itemconfigure(window_id, width=can_w if req_w <= can_w else req_w)
+
+        frame.bind("<Configure>", _sync_layout)
+        canvas.bind("<Configure>", _sync_layout)
+
+        self._root_scroll_canvas = canvas
+        self._root_scroll_window = int(window_id)
+        self._root_scroll_frame = frame
+        return frame
+
+    def _install_context_menu(self) -> None:
+        menu = tk.Menu(self.root, tearoff=0)
+        menu.add_command(label="Cofnij", command=lambda: self._context_emit("<<Undo>>"))
+        menu.add_command(label="Ponow", command=lambda: self._context_emit("<<Redo>>"))
+        menu.add_separator()
+        menu.add_command(label="Wytnij", command=lambda: self._context_emit("<<Cut>>"))
+        menu.add_command(label="Kopiuj", command=lambda: self._context_emit("<<Copy>>"))
+        menu.add_command(label="Wklej", command=lambda: self._context_emit("<<Paste>>"))
+        menu.add_command(label="Usun", command=lambda: self._context_emit("<<Clear>>"))
+        menu.add_separator()
+        menu.add_command(label="Zaznacz wszystko", command=self._context_select_all)
+        menu.add_command(label="Wyczysc pole", command=self._context_clear_field)
+
+        self._context_menu = menu
+        for cls in ("Entry", "TEntry", "Text", "TCombobox", "Spinbox", "TSpinbox", "Listbox"):
+            self.root.bind_class(cls, "<Button-3>", self._show_context_menu, add="+")
+            self.root.bind_class(cls, "<Shift-F10>", self._show_context_menu_keyboard, add="+")
+            self.root.bind_class(cls, "<Control-a>", self._context_select_all_event, add="+")
+            self.root.bind_class(cls, "<Control-A>", self._context_select_all_event, add="+")
+
+    def _show_context_menu(self, event: tk.Event) -> str:
+        if self._context_menu is None:
+            return "break"
+        widget = event.widget if isinstance(event.widget, tk.Misc) else None
+        if widget is None:
+            return "break"
+        self._context_target = widget
+        try:
+            widget.focus_set()
+        except Exception:
+            pass
+        try:
+            self._context_menu.tk_popup(int(event.x_root), int(event.y_root))
+        finally:
+            self._context_menu.grab_release()
+        return "break"
+
+    def _show_context_menu_keyboard(self, event: tk.Event) -> str:
+        widget = event.widget if isinstance(event.widget, tk.Misc) else None
+        if widget is None:
+            return "break"
+        if self._context_menu is None:
+            return "break"
+        self._context_target = widget
+        x = widget.winfo_rootx() + max(8, int(widget.winfo_width() * 0.2))
+        y = widget.winfo_rooty() + max(8, int(widget.winfo_height() * 0.8))
+        try:
+            self._context_menu.tk_popup(x, y)
+        finally:
+            self._context_menu.grab_release()
+        return "break"
+
+    def _context_emit(self, sequence: str) -> None:
+        widget = self._context_target
+        if widget is None:
+            return
+        try:
+            widget.event_generate(sequence)
+        except Exception:
+            pass
+
+    def _context_select_all(self) -> None:
+        widget = self._context_target
+        if widget is None:
+            return
+        cls = str(widget.winfo_class())
+        try:
+            if cls in {"Entry", "TEntry", "TCombobox", "Spinbox", "TSpinbox"}:
+                widget.selection_range(0, "end")  # type: ignore[attr-defined]
+                widget.icursor("end")  # type: ignore[attr-defined]
+            elif cls == "Text":
+                widget.tag_add("sel", "1.0", "end-1c")  # type: ignore[attr-defined]
+            elif cls == "Listbox":
+                widget.selection_set(0, "end")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+    def _context_select_all_event(self, event: tk.Event) -> str:
+        widget = event.widget if isinstance(event.widget, tk.Misc) else None
+        if widget is None:
+            return "break"
+        self._context_target = widget
+        self._context_select_all()
+        return "break"
+
+    def _context_clear_field(self) -> None:
+        widget = self._context_target
+        if widget is None:
+            return
+        cls = str(widget.winfo_class())
+        try:
+            if cls in {"Entry", "TEntry", "TCombobox", "Spinbox", "TSpinbox"}:
+                widget.delete(0, "end")  # type: ignore[attr-defined]
+            elif cls == "Text":
+                widget.delete("1.0", "end")  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
     def tr(self, key: str, default: str, **fmt: Any) -> str:
         return self.i18n.t(key, default, **fmt)
@@ -269,8 +449,7 @@ class TranslatorGUI:
 
     def _build_ui(self) -> None:
         self.root.title(self.tr("app.title", APP_TITLE))
-        outer = ttk.Frame(self.root, padding=16)
-        outer.pack(fill="both", expand=True)
+        outer = self._create_scrollable_root(padding=16)
 
         ttk.Label(outer, text=self.tr("app.title", APP_TITLE), style="Title.TLabel").pack(anchor="w")
         ttk.Label(
@@ -2451,8 +2630,7 @@ class TextEditorWindow:
         self.epub_path = epub_path
         self.win = tk.Toplevel(gui.root)
         self.win.title(self.gui.tr("editor.window_title", "EPUB text editor - {name}", name=epub_path.name))
-        self.win.geometry("1200x760")
-        self.win.minsize(1000, 650)
+        self.gui._configure_window_bounds(self.win, preferred_w=1200, preferred_h=760, min_w=760, min_h=520, maximize=True)
 
         self.chapter_entries = list_chapters(epub_path)
         self.current_chapter_path: Optional[str] = None

--- a/project-tkinter/start_horizon.py
+++ b/project-tkinter/start_horizon.py
@@ -40,8 +40,7 @@ class HorizonGUI(base.TranslatorGUI):
 
     def _build_ui(self) -> None:
         self.root.title("Translator Studio Horizon")
-        outer = ttk.Frame(self.root, padding=18, style="TFrame")
-        outer.pack(fill="both", expand=True)
+        outer = self._create_scrollable_root(padding=18)
 
         header = ttk.Frame(outer, style="Card.TFrame", padding=(18, 14))
         header.pack(fill="x")

--- a/project-tkinter/studio_suite.py
+++ b/project-tkinter/studio_suite.py
@@ -65,8 +65,7 @@ class StudioSuiteWindow:
         self.gui = gui
         self.win = tk.Toplevel(gui.root)
         self.win.title(self.gui.tr("studio.title", "Studio Tools"))
-        self.win.geometry("1200x820")
-        self.win.minsize(1020, 700)
+        self.gui._configure_window_bounds(self.win, preferred_w=1200, preferred_h=820, min_w=760, min_h=520, maximize=True)
         self.db_path = gui.workdir / "translator_studio.db"
         self._tooltips: List[Any] = []
         seg_mode = str(self.gui.db.get_setting("studio_segment_mode", "auto") or "auto").strip().lower()

--- a/project-web-desktop/desktop/main.js
+++ b/project-web-desktop/desktop/main.js
@@ -1,17 +1,50 @@
-const { app, BrowserWindow, dialog, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, Menu, clipboard, dialog, ipcMain, shell, screen } = require('electron');
 const path = require('path');
 
 function createWindow() {
+  const area = screen.getPrimaryDisplay().workArea;
+  const width = Math.min(Math.max(1100, area.width - 40), 1600);
+  const height = Math.min(Math.max(760, area.height - 40), 1100);
   const win = new BrowserWindow({
-    width: 1280,
-    height: 860,
-    minWidth: 1000,
-    minHeight: 700,
+    width,
+    height,
+    minWidth: 760,
+    minHeight: 520,
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
+  });
+
+  win.webContents.on('context-menu', (_event, params) => {
+    const selected = String(params.selectionText || '').trim();
+    const editable = Boolean(params.isEditable);
+    const hasSelection = selected.length > 0;
+    const hasLink = typeof params.linkURL === 'string' && params.linkURL.trim().length > 0;
+    const menu = Menu.buildFromTemplate([
+      { role: 'undo', enabled: editable },
+      { role: 'redo', enabled: editable },
+      { type: 'separator' },
+      { role: 'cut', enabled: editable },
+      { role: 'copy', enabled: editable || hasSelection },
+      { role: 'paste', enabled: editable },
+      { role: 'delete', enabled: editable },
+      { role: 'selectAll', enabled: editable || hasSelection },
+      { type: 'separator' },
+      { label: 'Kopiuj jako zwykly tekst', enabled: hasSelection, click: () => win.webContents.copy() },
+      { label: 'Otworz link', enabled: hasLink, click: () => shell.openExternal(params.linkURL) },
+      { label: 'Kopiuj adres linku', enabled: hasLink, click: () => clipboard.writeText(params.linkURL) },
+    ]);
+    menu.popup({ window: win });
+  });
+
+  win.once('ready-to-show', () => {
+    try {
+      win.maximize();
+    } catch {}
+    win.show();
   });
 
   win.loadFile(path.join(__dirname, 'renderer', 'index.html'));

--- a/project-web-desktop/desktop/renderer/styles.css
+++ b/project-web-desktop/desktop/renderer/styles.css
@@ -9,12 +9,15 @@
 }
 
 * { box-sizing: border-box; }
+html, body { height: 100%; }
 
 body {
   margin: 0;
   font-family: 'Segoe UI', 'Noto Sans', sans-serif;
   background: linear-gradient(155deg, #e9eef4, #f7fafc);
   color: var(--text);
+  min-width: 760px;
+  overflow: auto;
 }
 
 .topbar {
@@ -48,6 +51,7 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   padding: 18px;
+  min-width: 960px;
 }
 
 .card {
@@ -183,6 +187,7 @@ button:disabled { opacity: 0.6; cursor: not-allowed; }
 
 @media (max-width: 1250px) {
   .layout { grid-template-columns: 1fr; }
+  .layout { min-width: 760px; }
   .setup-grid { grid-template-columns: 1fr; }
   .grid, .grid.compact { grid-template-columns: 1fr; }
   .history { height: 240px; }


### PR DESCRIPTION
## Opis zmian
- Ujednolicono start okien w wariantach Tkinter i Web Desktop: okna startuja z dopasowanym rozmiarem i trybem maksymalnym.
- Dodano obsluge przewijania po zmniejszeniu glownego okna (scroll pion/poziom) w obu startach Tkinter (`start.py`, `start_horizon.py`).
- Dodano menu kontekstowe pod prawym klawiszem myszy (Undo/Redo/Cut/Copy/Paste/Delete/Select All + czyszczenie pola) dla pol edycyjnych Tkinter.
- Dodano natywne menu kontekstowe Electron (w tym akcje linkow) i poprawiono zachowanie layoutu CSS dla mniejszych szerokosci.
- Dodano dokumentacje: gdzie na ekranie widac postep projektu i jak obslugiwac status Wiki/Pages (`docs/08-Status-UI-i-Wiki.md`, aktualizacja README i troubleshooting).

## Powod zmiany
- Uzytkownik prowadzacy wiele projektow potrzebuje jasnej informacji "co dalej" i stabilnego UX przy zmianie rozmiaru okna.
- Dotychczas brakowalo spisanego miejsca, ktore jednoznacznie wskazuje gdzie widac postep i jak diagnozowac niedzialajace Wiki.

## Zakres
- [ ] backend
- [x] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [ ] refactor
- [x] bugfix

## Jak testowano
- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

Wykonane lokalnie:
- `python -m py_compile project-tkinter/start.py project-tkinter/start_horizon.py project-tkinter/studio_suite.py`
- `node --check project-web-desktop/desktop/main.js`
- `node --check project-web-desktop/desktop/renderer/app.js`

## Lista kontrolna
- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [ ] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
