### PR TITLE
chore: align ep2pl with new personal-use licensing baseline

### DIFF
--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -1,0 +1,44 @@
+# Commercial Licensing Policy
+
+This repository is distributed under a personal-use license by default.
+Commercial rights are not granted by default.
+
+## Default Rule
+
+1. Personal private use is free (unmodified copies).
+2. Any commercial use requires prior written agreement with the licensor.
+3. No commercial rights exist until both sides agree in writing.
+
+## What Counts as Commercial Use
+
+1. Use by a company or organization (including internal operations).
+2. SaaS, hosted services, APIs, paid subscriptions, or client delivery.
+3. Selling products/services that include this software.
+4. OEM, white-label, reseller, or bundled distribution.
+5. Any use connected to direct or indirect revenue.
+
+## Request Process
+
+Send a licensing request with:
+1. legal entity name and country,
+2. intended use (internal, SaaS, OEM, etc.),
+3. deployment model and estimated user scale,
+4. required rights (modification, redistribution, support),
+5. preferred timeline.
+
+Contact:
+- GitHub profile: https://github.com/piotrgrechuta-web
+- GitHub Sponsors page: https://github.com/sponsors/piotrgrechuta-web
+
+## Typical Commercial Terms (Negotiated)
+
+1. License scope (internal, SaaS, OEM, distribution).
+2. Fee model (one-time, annual, per-seat, or custom).
+3. Support/SLA scope and response times.
+4. Warranty/indemnity terms (if offered).
+5. Attribution/branding requirements (if any).
+
+## Important
+
+This document is a practical policy description.
+The binding legal terms are in the signed commercial agreement and in `LICENSE`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,131 +1,98 @@
-# PolyForm Noncommercial License 1.0.0
+EPUB Translator Studio Personal Use License v1.0
+Copyright (c) 2026 Piotr Grechuta
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+IMPORTANT: This is source-available software. It is not open source software
+as defined by OSI/FSF.
 
-## Acceptance
+By using, downloading, accessing, or running this software, you agree to this
+license.
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+1. Definitions
 
-## Copyright License
+  1.1 "Software" means the source code, binaries, documentation, and related
+      files in this repository.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+  1.2 "Licensor" means Piotr Grechuta, the copyright owner.
 
-## Distribution License
+  1.3 "Personal Use" means private, non-commercial use by a natural person for
+      personal purposes, with no direct or indirect commercial benefit.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+  1.4 "Commercial Use" means any use by or for a business, organization, or
+      revenue-generating activity, including internal business operations,
+      client services, SaaS/hosted offerings, paid support, paid distribution,
+      OEM/white-label use, or any use connected to commercial advantage.
 
-## Notices
+2. Personal Use Grant (Free)
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
+  2.1 Licensor grants you a limited, revocable, non-exclusive,
+      non-transferable, non-sublicensable license to use unmodified copies of
+      the Software for Personal Use only.
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+  2.2 You may make a reasonable number of local backup copies for your own
+      Personal Use.
 
-## Changes and New Works License
+3. Restrictions
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+  Unless Licensor gives prior written permission, you may not:
 
-## Patent License
+  3.1 modify, adapt, translate, reverse engineer, decompile, disassemble, or
+      create derivative works from the Software;
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+  3.2 redistribute, publish, sublicense, rent, lease, lend, sell, or otherwise
+      transfer the Software (in source or binary form) to third parties;
 
-## Noncommercial Purposes
+  3.3 use the Software for Commercial Use;
 
-Any noncommercial purpose is a permitted purpose.
+  3.4 remove or alter copyright, attribution, or legal notices.
 
-## Personal Uses
+4. Commercial Licensing
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+  4.1 Any Commercial Use requires a separate written commercial license
+      agreement with Licensor, agreed before Commercial Use begins.
 
-## Noncommercial Organizations
+  4.2 No Commercial Use rights are granted by this license.
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+  4.3 Commercial terms (scope, fee, support, warranty, redistribution rights)
+      are negotiated case by case and are effective only if signed by Licensor.
 
-## Fair Use
+5. Ownership
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+  5.1 The Software is licensed, not sold.
 
-## No Other Rights
+  5.2 All intellectual property rights remain with Licensor.
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+6. Contributions and Pull Requests
 
-## Patent Defense
+  6.1 Licensor may reject any contribution for any reason.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+  6.2 Submitting a contribution does not grant you any ownership in the
+      Software.
 
-## Violations
+  6.3 Licensor may require a separate written agreement (for example CLA or
+      assignment) before accepting contributions.
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+7. Termination
 
-## No Liability
+  7.1 This license terminates automatically if you violate any term.
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+  7.2 On termination, you must stop using the Software and delete all copies in
+      your possession or control.
 
-## Definitions
+8. Disclaimer of Warranty
 
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS
+  FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
-**You** refers to the individual or entity agreeing to these
-terms.
+9. Limitation of Liability
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
+  TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR IS NOT LIABLE FOR ANY CLAIM,
+  DAMAGES, OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT, OR OTHERWISE, ARISING
+  FROM OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
+10. Contact
 
-**Use** means anything you do with the software requiring one
-of your licenses.
+  Commercial licensing requests: see COMMERCIAL_LICENSE.md
+  Project owner profile: https://github.com/piotrgrechuta-web
+

--- a/LICENSE_GUIDE_DE.md
+++ b/LICENSE_GUIDE_DE.md
@@ -1,38 +1,34 @@
 # Lizenz - einfache erklaerung und beispiele
 
-Dieses Projekt steht unter `PolyForm Noncommercial 1.0.0`.
+Dieses Projekt wird bereitgestellt unter:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-Kurz gesagt:
-- du darfst den Code kopieren,
-- du darfst den Code aendern,
-- du darfst das Projekt ausfuehren,
-- aber nur fuer nichtkommerzielle Zwecke.
+Das ist source-available, aber kein OSI/FSF Open Source.
 
-Die vollstaendigen Regeln stehen in `LICENSE`.
-Pflicht-Hinweise zum Autor stehen in `NOTICE`.
+## Kurzfassung
+
+1. Private Nutzung unveraenderter Kopien ist kostenlos.
+2. Aenderungen am Code sind ohne schriftliche Erlaubnis nicht erlaubt.
+3. Weitergabe/Redistribution ist ohne schriftliche Erlaubnis nicht erlaubt.
+4. Kommerzielle Nutzung ist nur mit unterschriebener kommerzieller Lizenz erlaubt.
+
+Volle Regeln stehen in `LICENSE`.
+Der kommerzielle Weg steht in `COMMERCIAL_LICENSE.md`.
 
 ## Erlaubt (beispiele)
 
-1. Private Nutzung zum Lernen und Testen.
-2. Fork fuer Hobbyprojekt.
-3. Nutzung in Schule oder Non-Profit-Organisation.
-4. Weitergabe von Verbesserungen ohne Bezahlung.
+1. App privat auf dem eigenen Rechner nutzen.
+2. Unveraenderte Version fuer private EPUB-Arbeit verwenden.
+3. Lokale private Backups behalten.
 
 ## Nicht erlaubt (beispiele)
 
-1. Verkauf der App oder bezahlter Zugang.
-2. Bezahlter Dienst auf Basis dieses Codes.
-3. Integration in kommerzielles Produkt oder SaaS.
-4. Nutzung fuer gewinnorientierte Geschaeftszwecke.
-
-## Was in Kopien/Forks erhalten bleiben muss
-
-1. `LICENSE`
-2. `NOTICE` (inklusive `Required Notice:` Zeilen)
-3. `AUTHORS`
+1. Einsatz im bezahlten Service oder im Unternehmens-Workflow.
+2. Einbau in SaaS/kommerzielles Produkt.
+3. Veroeffentlichung von Forks, modifizierten Versionen oder repackten Installern.
+4. Entfernen von Autor- oder Rechtshinweisen.
 
 ## Wichtig
 
-Diese Datei ist nur eine praktische Hilfe.
-Bei Konflikten gilt der verbindliche Text in `LICENSE`.
-
+Diese Datei ist eine praktische Hilfe.
+Bei Konflikten gilt `LICENSE` als verbindlicher Rechtstext.

--- a/LICENSE_GUIDE_EN.md
+++ b/LICENSE_GUIDE_EN.md
@@ -1,38 +1,34 @@
 # License - simple explanation and examples
 
-This project is distributed under `PolyForm Noncommercial 1.0.0`.
+This project is distributed under:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-In short:
-- you can copy the code,
-- you can modify the code,
-- you can run the project,
-- but only for noncommercial purposes.
+This is source-available software, not OSI/FSF open source.
+
+## In short
+
+1. Personal private use of unmodified copies is free.
+2. Modification is not allowed without written permission.
+3. Redistribution is not allowed without written permission.
+4. Commercial use is not allowed without a signed commercial agreement.
 
 Full legal terms are in `LICENSE`.
-Required author notices are in `NOTICE`.
+Commercial process is in `COMMERCIAL_LICENSE.md`.
 
 ## Allowed (examples)
 
-1. Personal learning and experimentation.
-2. Forking for hobby or private testing.
-3. Educational or nonprofit internal use.
-4. Sharing fixes without charging users.
+1. Download and run the app privately on your own machine.
+2. Use the unmodified app for personal EPUB work.
+3. Keep local personal backups.
 
 ## Not allowed (examples)
 
-1. Selling the app or paid access to it.
-2. Paid service built on this code.
-3. Including this code in a commercial product or SaaS.
-4. Business use intended for profit.
-
-## What must be preserved in copies/forks
-
-1. `LICENSE`
-2. `NOTICE` (including `Required Notice:` lines)
-3. `AUTHORS`
+1. Using the software in a paid service or company workflow.
+2. Shipping the code in a SaaS/product bundle.
+3. Publishing forks, modified versions, or repackaged installers.
+4. Removing author/legal notices.
 
 ## Important
 
 This file is a practical guide.
 If there is any conflict, `LICENSE` is the binding legal text.
-

--- a/LICENSE_GUIDE_ES.md
+++ b/LICENSE_GUIDE_ES.md
@@ -1,38 +1,34 @@
 # Licencia - explicacion simple y ejemplos
 
-Este proyecto se distribuye con `PolyForm Noncommercial 1.0.0`.
+Este proyecto se distribuye bajo:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-En resumen:
-- puedes copiar el codigo,
-- puedes modificar el codigo,
-- puedes ejecutar el proyecto,
-- pero solo para fines no comerciales.
+Es software source-available, no open source OSI/FSF.
+
+## En resumen
+
+1. El uso privado de copias sin modificar es gratuito.
+2. Modificar el codigo sin permiso escrito no esta permitido.
+3. Redistribuir sin permiso escrito no esta permitido.
+4. El uso comercial solo se permite con licencia comercial firmada.
 
 Las reglas completas estan en `LICENSE`.
-Las notas obligatorias del autor estan en `NOTICE`.
+El proceso comercial esta en `COMMERCIAL_LICENSE.md`.
 
 ## Permitido (ejemplos)
 
-1. Uso personal para aprender y experimentar.
-2. Fork para hobby o pruebas privadas.
-3. Uso interno en educacion o nonprofit.
-4. Compartir mejoras sin cobrar.
+1. Descargar y ejecutar la app en tu equipo personal.
+2. Usar la version sin modificar para trabajo EPUB privado.
+3. Mantener copias de respaldo privadas.
 
 ## No permitido (ejemplos)
 
-1. Vender la app o acceso de pago.
-2. Servicio de pago basado en este codigo.
-3. Incluir este codigo en producto comercial o SaaS.
-4. Uso empresarial orientado a beneficio economico.
-
-## Que debes conservar en copias/forks
-
-1. `LICENSE`
-2. `NOTICE` (incluyendo lineas `Required Notice:`)
-3. `AUTHORS`
+1. Usar el software en un servicio de pago o flujo empresarial.
+2. Integrar el codigo en SaaS o producto comercial.
+3. Publicar forks, versiones modificadas o instaladores reempaquetados.
+4. Eliminar avisos de autoria o avisos legales.
 
 ## Importante
 
 Este archivo es una guia practica.
-Si hay conflicto, manda el texto legal de `LICENSE`.
-
+Si hay conflicto, `LICENSE` es el texto legal vinculante.

--- a/LICENSE_GUIDE_FR.md
+++ b/LICENSE_GUIDE_FR.md
@@ -1,38 +1,34 @@
 # Licence - explication simple et exemples
 
-Ce projet est distribue sous `PolyForm Noncommercial 1.0.0`.
+Ce projet est distribue sous:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-En bref:
-- vous pouvez copier le code,
-- vous pouvez modifier le code,
-- vous pouvez executer le projet,
-- mais uniquement pour des usages non commerciaux.
+C'est du source-available, pas de l'open source OSI/FSF.
 
-Les conditions completes sont dans `LICENSE`.
-Les mentions auteur obligatoires sont dans `NOTICE`.
+## En bref
+
+1. L'usage prive de copies non modifiees est gratuit.
+2. Modifier le code sans autorisation ecrite n'est pas autorise.
+3. Redistribuer sans autorisation ecrite n'est pas autorise.
+4. L'usage commercial exige une licence commerciale signee.
+
+Le texte complet est dans `LICENSE`.
+Le processus commercial est dans `COMMERCIAL_LICENSE.md`.
 
 ## Autorise (exemples)
 
-1. Usage personnel pour apprendre et tester.
-2. Fork pour hobby ou tests prives.
-3. Usage interne education/nonprofit.
-4. Partage des correctifs sans facturation.
+1. Telecharger et executer l'app sur votre machine personnelle.
+2. Utiliser la version non modifiee pour votre travail EPUB prive.
+3. Garder des sauvegardes privees locales.
 
 ## Non autorise (exemples)
 
-1. Vente de l'app ou acces payant.
-2. Service payant base sur ce code.
-3. Integration dans un produit commercial ou SaaS.
-4. Usage business pour generer du profit.
-
-## A conserver dans les copies/forks
-
-1. `LICENSE`
-2. `NOTICE` (avec lignes `Required Notice:`)
-3. `AUTHORS`
+1. Utiliser le logiciel dans un service payant ou workflow d'entreprise.
+2. Integrer le code dans un SaaS ou produit commercial.
+3. Publier des forks, versions modifiees ou installateurs repackages.
+4. Supprimer les mentions d'auteur ou mentions legales.
 
 ## Important
 
 Ce fichier est un guide pratique.
-En cas de conflit, `LICENSE` reste le texte legal applicable.
-
+En cas de conflit, `LICENSE` est le texte legal applicable.

--- a/LICENSE_GUIDE_PL.md
+++ b/LICENSE_GUIDE_PL.md
@@ -1,38 +1,34 @@
 # Licencja - proste wyjasnienie i przyklady
 
-Ten projekt jest udostepniony na licencji `PolyForm Noncommercial 1.0.0`.
+Ten projekt jest udostepniony na:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-W skrocie:
-- mozna kopiowac kod,
-- mozna modyfikowac kod,
-- mozna uruchamiac projekt,
-- ale tylko w celach niekomercyjnych.
+To jest model source-available, a nie open source OSI/FSF.
+
+## W skrocie
+
+1. Prywatne uzycie niezmienionej wersji jest darmowe.
+2. Modyfikacja kodu wymaga pisemnej zgody autora.
+3. Redystrybucja wymaga pisemnej zgody autora.
+4. Uzycie komercyjne wymaga podpisanej umowy komercyjnej.
 
 Pelne zasady sa w `LICENSE`.
-Dodatkowe oznaczenia autora i wymagane noty sa w `NOTICE`.
+Sciezka komercyjna jest opisana w `COMMERCIAL_LICENSE.md`.
 
 ## Co jest dozwolone (przyklady)
 
-1. Uzywasz projektu prywatnie do nauki.
-2. Robisz fork i testujesz we wlasnym hobby projekcie.
-3. Szkola lub organizacja non-profit wykorzystuje narzedzie edukacyjnie.
-4. Modyfikujesz kod lokalnie i dzielisz sie poprawkami, bez pobierania oplat.
+1. Pobranie i uruchamianie aplikacji prywatnie na swoim komputerze.
+2. Uzywanie niezmienionej wersji do prywatnej pracy z EPUB.
+3. Trzymanie lokalnych kopii zapasowych do uzytku prywatnego.
 
 ## Co nie jest dozwolone (przyklady)
 
-1. Sprzedaz aplikacji lub dostepu do niej.
-2. Oferowanie platnej uslugi opartej na tym kodzie.
-3. Dolaczenie kodu do komercyjnego produktu lub SaaS.
-4. Wykorzystanie kodu do celow biznesowych nastawionych na zysk.
-
-## Co trzeba zachowac przy kopiowaniu/forku
-
-1. Plik `LICENSE`.
-2. Plik `NOTICE` (w tym linie `Required Notice:`).
-3. Informacje o autorze z `AUTHORS`.
+1. Uzywanie aplikacji w platnej usludze lub workflow firmy.
+2. Dolaczanie kodu do SaaS/produktu komercyjnego.
+3. Publikowanie forkow, zmodyfikowanych wersji lub przepakowanych instalatorow.
+4. Usuwanie informacji o autorze i not prawnych.
 
 ## Wazne
 
-Ten dokument jest praktycznym opisem dla uzytkownika.
-W przypadku sporu obowiazuje pelny tekst licencji z pliku `LICENSE`.
-
+Ten dokument jest praktycznym opisem.
+W przypadku sporu obowiazuje pelny tekst z pliku `LICENSE`.

--- a/LICENSE_GUIDE_PT.md
+++ b/LICENSE_GUIDE_PT.md
@@ -1,38 +1,34 @@
 # Licenca - explicacao simples e exemplos
 
-Este projeto e distribuido sob `PolyForm Noncommercial 1.0.0`.
+Este projeto e distribuido sob:
+`EPUB Translator Studio Personal Use License v1.0`.
 
-Em resumo:
-- voce pode copiar o codigo,
-- voce pode modificar o codigo,
-- voce pode executar o projeto,
-- mas apenas para fins nao comerciais.
+Este modelo e source-available, nao open source OSI/FSF.
+
+## Em resumo
+
+1. O uso privado de copias sem modificacao e gratuito.
+2. Modificar o codigo sem autorizacao escrita nao e permitido.
+3. Redistribuir sem autorizacao escrita nao e permitido.
+4. Uso comercial so com licenca comercial assinada.
 
 As regras completas estao em `LICENSE`.
-As notas obrigatorias de autoria estao em `NOTICE`.
+O processo comercial esta em `COMMERCIAL_LICENSE.md`.
 
 ## Permitido (exemplos)
 
-1. Uso pessoal para estudo e testes.
-2. Fork para hobby ou testes privados.
-3. Uso interno em educacao ou nonprofit.
-4. Compartilhar melhorias sem cobranca.
+1. Baixar e executar o app no seu computador pessoal.
+2. Usar a versao sem modificacao para trabalho EPUB privado.
+3. Manter backups privados locais.
 
 ## Nao permitido (exemplos)
 
-1. Vender o app ou acesso pago.
-2. Servico pago baseado neste codigo.
-3. Incluir este codigo em produto comercial ou SaaS.
-4. Uso empresarial com objetivo de lucro.
-
-## O que manter em copias/forks
-
-1. `LICENSE`
-2. `NOTICE` (incluindo linhas `Required Notice:`)
-3. `AUTHORS`
+1. Usar o software em servico pago ou fluxo de empresa.
+2. Integrar o codigo em SaaS ou produto comercial.
+3. Publicar forks, versoes modificadas ou instaladores reempacotados.
+4. Remover avisos de autoria ou avisos legais.
 
 ## Importante
 
 Este arquivo e um guia pratico.
 Em caso de conflito, `LICENSE` e o texto legal vinculante.
-

--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,12 @@
-Required Notice: Copyright (c) 2026 Piotr Grechuta.
-Required Notice: Attribution to the original creator of EPUB Translator Studio must be preserved in redistributions and derivative works.
+EPUB Translator Studio
+Copyright (c) 2026 Piotr Grechuta
 
-Project: EPUB Translator Studio
-Creator: Piotr Grechuta (GitHub: piotrgrechuta-web)
+Licensing summary:
+- Personal use of unmodified copies is free.
+- Modification, redistribution, and commercial use require prior written
+  permission from the licensor.
+- Commercial terms are negotiated individually.
 
-Please do not remove or alter creator attribution, copyright notices,
-or Required Notice lines in this repository and its derivative copies.
-
-If you modify files, clearly mark your changes and date them.
-
+See:
+- LICENSE
+- COMMERCIAL_LICENSE.md

--- a/README.de.md
+++ b/README.de.md
@@ -45,7 +45,8 @@ cd project-web-desktop
 - Support Info (PL): `SUPPORT_PL.md`
 
 ## Lizenz
-- Lizenz: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- Kopieren und Aendern nur fuer nichtkommerzielle Zwecke.
-- Hinweise auf Urheber und Required Notice behalten (`NOTICE`, `AUTHORS`).
+- Lizenz: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- Dieses Projekt ist source-available und kein OSI/FSF Open Source.
+- Kostenfrei ist nur private Nutzung unveraenderter Kopien.
+- Jede Aenderung, Weitergabe oder kommerzielle Nutzung braucht eine vorherige schriftliche Genehmigung (`COMMERCIAL_LICENSE.md`).
 - Praxisbeispiele (DE): `LICENSE_GUIDE_DE.md`

--- a/README.es.md
+++ b/README.es.md
@@ -45,7 +45,8 @@ cd project-web-desktop
 - Soporte (PL): `SUPPORT_PL.md`
 
 ## Licencia
-- Licencia: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- Puedes copiar y modificar solo para fines no comerciales.
-- Mantener atribucion del autor y Required Notice (`NOTICE`, `AUTHORS`).
+- Licencia: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- Este proyecto es source-available y no es open source OSI/FSF.
+- El uso privado de copias sin modificar es gratuito.
+- Cualquier modificacion, redistribucion o uso comercial requiere acuerdo escrito previo (`COMMERCIAL_LICENSE.md`).
 - Ejemplos practicos (ES): `LICENSE_GUIDE_ES.md`

--- a/README.fr.md
+++ b/README.fr.md
@@ -45,7 +45,8 @@ cd project-web-desktop
 - Infos support (PL): `SUPPORT_PL.md`
 
 ## Licence
-- Licence: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- Copie et modification autorisees uniquement pour usage non commercial.
-- Conserver attribution auteur et Required Notice (`NOTICE`, `AUTHORS`).
+- Licence: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- Ce projet est source-available et n'est pas open source OSI/FSF.
+- L'usage prive de copies non modifiees est gratuit.
+- Toute modification, redistribution ou usage commercial exige un accord ecrit prealable (`COMMERCIAL_LICENSE.md`).
 - Exemples pratiques (FR): `LICENSE_GUIDE_FR.md`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PR checks](https://github.com/piotrgrechuta-web/epu2pl/actions/workflows/pr-checks.yml/badge.svg?branch=master)](https://github.com/piotrgrechuta-web/epu2pl/actions/workflows/pr-checks.yml)
 [![Release](https://img.shields.io/github/v/release/piotrgrechuta-web/epu2pl?display_name=tag)](https://github.com/piotrgrechuta-web/epu2pl/releases)
-[![License: PolyForm Noncommercial 1.0.0](https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-orange.svg)](LICENSE)
+[![License: Personal Use Only](https://img.shields.io/badge/license-Personal%20Use%20Only-red.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](project-web-desktop/backend/requirements.txt)
 
 Language: **English** | [Polski](README.pl.md) | [Deutsch](README.de.md) | [Espanol](README.es.md) | [Francais](README.fr.md) | [Portugues](README.pt.md)
@@ -111,9 +111,10 @@ This keeps core runtime behavior synchronized across both variants.
 - ready first release draft (PL): `.github/RELEASE_DRAFT_PL.md`
 
 ## License
-- License: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- You can copy and modify the code for noncommercial purposes.
-- Keep creator attribution and required notices in redistributions (`NOTICE`, `AUTHORS`).
+- License: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- This project is source-available, not OSI/FSF open source.
+- Free for personal private use of unmodified copies.
+- Any modification, redistribution, or commercial use requires prior written agreement (`COMMERCIAL_LICENSE.md`).
 - Practical examples:
   - EN: `LICENSE_GUIDE_EN.md`
   - PL: `LICENSE_GUIDE_PL.md`

--- a/README.pl.md
+++ b/README.pl.md
@@ -106,9 +106,10 @@ Dzieki temu zachowanie logiki runtime jest synchronizowane miedzy wariantami.
 - gotowy szkic pierwszego release (PL): `.github/RELEASE_DRAFT_PL.md`
 
 ## Licencja
-- Licencja: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- Mozna kopiowac i modyfikowac kod do celow niekomercyjnych.
-- Przy kopiowaniu/forku trzeba zachowac informacje o autorze i Required Notice (`NOTICE`, `AUTHORS`).
+- Licencja: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- Ten projekt jest source-available i nie jest open source (OSI/FSF).
+- Darmowe jest prywatne uzycie niezmienionej wersji.
+- Kazda modyfikacja, redystrybucja lub uzycie komercyjne wymaga pisemnej zgody (`COMMERCIAL_LICENSE.md`).
 - Proste przyklady:
   - EN: `LICENSE_GUIDE_EN.md`
   - PL: `LICENSE_GUIDE_PL.md`

--- a/README.pt.md
+++ b/README.pt.md
@@ -45,7 +45,8 @@ cd project-web-desktop
 - Informacoes de suporte (PL): `SUPPORT_PL.md`
 
 ## Licenca
-- Licenca: `PolyForm Noncommercial 1.0.0` (`LICENSE`)
-- Voce pode copiar e modificar apenas para fins nao comerciais.
-- Mantenha atribuicao do autor e Required Notice (`NOTICE`, `AUTHORS`).
+- Licenca: `EPUB Translator Studio Personal Use License v1.0` (`LICENSE`)
+- Este projeto e source-available e nao e open source OSI/FSF.
+- O uso privado de copias sem modificacao e gratuito.
+- Qualquer modificacao, redistribuicao ou uso comercial exige acordo escrito previo (`COMMERCIAL_LICENSE.md`).
 - Exemplos praticos (PT): `LICENSE_GUIDE_PT.md`


### PR DESCRIPTION
﻿## Opis zmian

- Wyrównanie gałęzi `ep2pl` do aktualnego stanu `master` po zmianie modelu licencyjnego.
- Przeniesienie nowej licencji personal-use (`LICENSE`), polityki komercyjnej (`COMMERCIAL_LICENSE.md`) i aktualizacji README/licence-guide do `ep2pl`.
- Zapewnienie, że obie główne wersje projektu mają identyczne zasady prawne i komunikację licencyjną.

## Powod zmiany

- Po merge PR #7 do `master`, gałąź `ep2pl` została za aktualnym baseline'em licencyjnym.
- Celem jest spójność prawna i brak rozjazdu dokumentacji między wersjami projektu.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [ ] refactor
- [x] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

Sprawdzenia:
- `git diff --quiet origin/ep2pl..origin/master` (przed PR: roznice istnialy, po merge cel: brak roznic tresci).
- workflow PR checks + validate-pr-body.

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [ ] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
