### PR TITLE
feat(ui): execute M1 status consistency, timeline, and run telemetry

### DIFF
--- a/docs/08-Status-UI-i-Wiki.md
+++ b/docs/08-Status-UI-i-Wiki.md
@@ -14,11 +14,13 @@ Ekran: sekcja `Projekt i profile` (lewy panel, u gory).
 Najwazniejsze elementy:
 - licznik statusow wszystkich projektow: `idle/pending/running/error`,
 - lista statusu projektow z podsumowaniem ksiazki i etapow,
+- statusy etapow `T/R` sa ujednolicone miedzy aplikacjami: `none/pending/running/ok/error`,
 - format wpisu:
   - `ks=<book> | T:<done>/<total> <status> | R:<done>/<total> <status> | -> <next_action>`.
 
 Dodatkowo:
-- `Historia runow` pokazuje ostatnie uruchomienia aktywnego projektu,
+- panel `Ostatnie akcje (timeline projektu)` pokazuje ostatnie uruchomienia aktywnego projektu,
+- linia `Metryki runu` pokazuje czas, segmenty, cache/TM i reuse-rate dla ostatniego runu,
 - sekcja `Uruchomienie` pokazuje biezacy status procesu i postep.
 
 ## Gdzie widac postep projektu (Web Desktop)
@@ -26,6 +28,8 @@ Dodatkowo:
 Ekran: gora aplikacji web-desktop (`project-web-desktop`):
 - rozwijana lista projektu zawiera skrot statusu i podsumowanie etapow,
 - pole `Podsumowanie projektu` pokazuje ksiazke + T/R + nastepna akcje.
+- panel `Metryki runu` pokazuje czas, segmenty, cache/TM i reuse-rate.
+- panel `Ostatnie akcje (timeline projektu)` pokazuje ostatnie runy.
 
 Format jest spojny z wariantem Tkinter:
 - `ks=<book> | T:<done>/<total> <status> | R:<done>/<total> <status> | -> <next_action>`.

--- a/docs/09-Backlog-do-uzgodnienia.md
+++ b/docs/09-Backlog-do-uzgodnienia.md
@@ -1,0 +1,104 @@
+# 09. Backlog do uzgodnienia
+
+Status:
+- `M1 wdrozone` w kodzie i dokumentacji (2026-02-08),
+- `M2/M3` gotowe do publikacji jako kolejne Issues/Milestones.
+
+## Cel
+
+Zamienic roadmape na konkretne, mierzalne zadania z jasnym zakresem i kryteriami akceptacji.
+
+## Proponowane milestone'y
+
+1. `M1: UI Consistency + UX Telemetry`
+2. `M2: CI Hardening + Test Coverage`
+3. `M3: Workflow + Docs + Wiki`
+
+## M1: UI Consistency + UX Telemetry
+
+Status M1: `zrealizowane`.
+
+### Issue 1: Ujednolicenie statusow etapow (Tkinter + Web)
+- Zakres:
+  - jedno slownictwo i mapowanie statusow (`idle/pending/running/ok/error`) w obu interfejsach,
+  - jeden format podsumowania projektu.
+- Done:
+  - te same statusy widoczne w `project-tkinter` i `project-web-desktop`,
+  - test manualny: ten sam projekt pokazuje zgodne statusy po odswiezeniu UI.
+
+### Issue 2: Panel "Ostatnie akcje" (inline timeline)
+- Zakres:
+  - timeline ostatnich zdarzen runu/projektu bez otwierania osobnego popupu,
+  - stale miejsce na ekranie glownym.
+- Done:
+  - min. 20 ostatnich wpisow,
+  - wpis zawiera czas + krok + status + skrot komunikatu.
+
+### Issue 3: Mini-metryki runu
+- Zakres:
+  - czas runu,
+  - segmenty przetworzone,
+  - hit-rate cache/TM.
+- Done:
+  - metryki widoczne po zakonczeniu runu w obu interfejsach,
+  - brak regresji aktualnego logowania.
+
+## M2: CI Hardening + Test Coverage
+
+### Issue 4: Testy jednostkowe backend parsera EPUB
+- Zakres:
+  - testy OPF/spine/manifest,
+  - testy bezpiecznej segmentacji XHTML (inline tags).
+- Done:
+  - testy uruchamiane w CI,
+  - minimalne pokrycie dla krytycznych sciezek parsera.
+
+### Issue 5: Smoke API backendu
+- Zakres:
+  - testy endpointow zdrowia i statusu (`/health`, `/run/status`, lista projektow).
+- Done:
+  - zielony smoke w PR checks,
+  - czytelny raport bledu przy regresji.
+
+### Issue 6: Skan sekretow i zaleznosci
+- Zakres:
+  - skan sekretow w CI,
+  - podstawowy audit zaleznosci.
+- Done:
+  - workflow blokuje merge przy krytycznych wynikach.
+
+## M3: Workflow + Docs + Wiki
+
+### Issue 7: Inicjalizacja i utrzymanie Wiki
+- Zakres:
+  - utworzenie pierwszej strony wiki (`Home`),
+  - dodanie menu bocznego i linkow do `docs/`.
+- Done:
+  - `/wiki` dziala bez przekierowania na strone repo,
+  - wiki ma minimum 1 strone i sidebar.
+
+### Issue 8: Release checklist i changelog discipline
+- Zakres:
+  - szablon release notes z sekcjami: zmiany, ryzyka, migracja, testy,
+  - checklista przed tagiem/release.
+- Done:
+  - kazdy release ma jednolity opis i jasny scope.
+
+### Issue 9: Dokumentacja "2 komputery" + odzyskiwanie po awarii
+- Zakres:
+  - dopisanie scenariuszy odzyskiwania (db/cache/lock),
+  - szybki playbook "co robic po crashu".
+- Done:
+  - instrukcja krok-po-kroku w `docs/03` lub nowym rozdziale.
+
+## Kolejnosc realizacji (propozycja)
+
+1. M1 (widoczne efekty dla uzytkownika od razu)
+2. M2 (stabilnosc i bezpieczenstwo procesu wydawniczego)
+3. M3 (dokumentacja, wiki, release discipline)
+
+## Pytania do zatwierdzenia przed publikacja Issues
+
+1. Czy publikujemy wszystkie 9 issue od razu, czy tylko M1 jako sprint 1?
+2. Czy chcesz etykiety (`ui`, `backend`, `ci`, `docs`, `priority-high`)?
+3. Czy milestone'y ustawic na daty, czy bez dat (rolling)?

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ To jest strona startowa dla GitHub Pages (`/docs`).
 6. [Troubleshooting](06-Troubleshooting.md)
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
 8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
+9. [Backlog i kolejne etapy](09-Backlog-do-uzgodnienia.md)
 
 ## Zrodla
 

--- a/project-tkinter/docs-modern-ui/ui-modernization-plan.md
+++ b/project-tkinter/docs-modern-ui/ui-modernization-plan.md
@@ -48,6 +48,11 @@ Zrobione:
 ## Proponowany kolejny etap
 
 ## Etap 6: Spojnosc komunikatow i telemetry UX
-- standaryzacja slownictwa statusow (`ok/warn/error`) miedzy Tkinter i web-desktop,
-- panel "ostatnie akcje" (inline timeline) zamiast czesci popupow,
-- licznik czasu operacji i mini-metryki (czas runu, hit-rate cache/TM) bez wchodzenia do logu.
+- [x] Standaryzacja slownictwa statusow miedzy Tkinter i web-desktop.
+- [x] Panel "ostatnie akcje" (inline timeline) dla aktywnego projektu.
+- [x] Mini-metryki runu (czas, segmenty, cache/TM, reuse-rate) widoczne w UI.
+
+Zrobione:
+- statusy etapow (`none/pending/running/ok/error`) sa spojne miedzy wariantami UI,
+- oba UI pokazuja timeline ostatnich uruchomien projektu,
+- oba UI pokazuja metryki ostatniego runu bez wchodzenia do surowego logu.

--- a/project-web-desktop/desktop/renderer/index.html
+++ b/project-web-desktop/desktop/renderer/index.html
@@ -196,11 +196,12 @@
           <button id="stop-run-all-btn">Stop run-all</button>
         </div>
         <div id="status" class="status">Status: --</div>
+        <div id="run_metrics" class="status">Metryki runu: brak</div>
         <p id="msg" class="msg"></p>
       </section>
 
       <section class="card">
-        <h2>Historia projektu</h2>
+        <h2>Ostatnie akcje (timeline projektu)</h2>
         <pre id="history" class="history"></pre>
       </section>
 


### PR DESCRIPTION
## Opis zmian
- Wdrozono M1 dla obu interfejsow: standaryzacja statusow projektu i etapow (`idle/pending/running/ok/error` + `none` dla etapow).
- Dodano panel metryk runu (czas, segmenty, cache/TM, reuse-rate) w Tkinter i Web Desktop.
- Rozszerzono backend web o parsowanie logu runtime i zapis metryk do historii runow (`runs`), wraz z serializacja metryk w API.
- Uspojniono timeline uruchomien i podsumowania projektu miedzy Tkinter i Web Desktop.
- Zaktualizowano dokumentacje statusu UI i plan modernizacji (M1 jako zrealizowany).

## Powod zmiany
- Uzytkownik mial problem z jednoznacznym odczytem etapu projektu i co dalej wykonac.
- Celem bylo wdrozenie M1: ta sama semantyka statusow + widoczne "ostatnie akcje" + metryki runu bez wchodzenia do surowego logu.

## Zakres
- [x] backend
- [x] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [x] refactor
- [x] bugfix

## Jak testowano
- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

## Lista kontrolna
- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [ ] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
