### PR TITLE
sync: align ep2pl with master after cleanup

### DIFF
--- a/.github/REPO_PROFILE_SETUP_PL.md
+++ b/.github/REPO_PROFILE_SETUP_PL.md
@@ -3,14 +3,14 @@
 Gotowy pakiet ustawien strony repo pod widocznosc i sponsorowanie.
 
 Repo:
-- https://github.com/piotrgrechuta-web/epu2pl
+- https://github.com/piotrgrechuta-web/epub-translator-studio
 
 ## 1) Description (GitHub -> About)
 
 Wklej:
 
 ```text
-Desktop toolkit for AI-assisted EPUB translation, editing and QA workflows (Tkinter + Electron/FastAPI).
+Desktop toolkit for AI-assisted EPUB translation, editing and QA workflows (Tkinter).
 ```
 
 ## 2) Website (GitHub -> About)
@@ -18,7 +18,7 @@ Desktop toolkit for AI-assisted EPUB translation, editing and QA workflows (Tkin
 Wklej:
 
 ```text
-https://github.com/piotrgrechuta-web/epu2pl/releases
+https://github.com/piotrgrechuta-web/epub-translator-studio/releases
 ```
 
 ## 3) Topics (GitHub -> About)
@@ -36,8 +36,6 @@ translation-memory
 qa
 python
 tkinter
-electron
-fastapi
 localization
 epubcheck
 ```

--- a/.github/SPONSORS_OUTREACH_PACK_PL.md
+++ b/.github/SPONSORS_OUTREACH_PACK_PL.md
@@ -8,7 +8,7 @@ Link sponsors:
 ## 1) Krotki opis projektu (1 zdanie)
 
 ```text
-EPUB Translator Studio to zestaw narzedzi desktop (Tkinter + web-desktop) do tlumaczenia, redakcji i walidacji EPUB z AI.
+EPUB Translator Studio to zestaw narzedzi desktop (Tkinter) do tlumaczenia, redakcji i walidacji EPUB z AI.
 ```
 
 ## 2) CTA do README / release notes

--- a/.github/SPONSORS_PROFILE_TEMPLATE_PL.md
+++ b/.github/SPONSORS_PROFILE_TEMPLATE_PL.md
@@ -18,7 +18,7 @@ Wklej:
 ```text
 Czesc! Nazywam sie Piotr Grechuta.
 
-Rozwijam projekt epu2pl / Translator Studio: aplikacje desktop i web do pracy z EPUB
+Rozwijam projekt EPUB Translator Studio: aplikacja desktop Tkinter do pracy z EPUB
 (tlumaczenie, redakcja, walidacja, kolejka projektow, profile ustawien).
 
 Wsparcie finansowe przeznaczam na:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__/
 *.py[cod]
+.venv/
+venv/
+node_modules/
 
 # Runtime/cache outputs
 cache_*.jsonl
@@ -16,8 +19,6 @@ translator_studio.db-*
 project-tkinter/translator_studio.db
 project-tkinter/translator_studio.db-*
 project-tkinter/translator_studio.db.init.lock
-project-web-desktop/backend/translator_studio.db
-project-web-desktop/backend/translator_studio.db-*
 
 # Local app/session settings
 .last_session.json
@@ -27,5 +28,3 @@ project-web-desktop/backend/translator_studio.db-*
 AIza*
 *.key
 *.secret
-
-project-web-desktop/desktop/node_modules/electron/dist/electron.exe


### PR DESCRIPTION
## Opis zmian

- synchronizacja `master` -> `ep2pl` po cleanupie pozostalosci po wariancie web.
- aktualizacja `.gitignore` i materialow `.github/*` pod stan Tkinter-only.

## Powod zmiany

- utrzymanie spojnosci miedzy glownymi galeziami repo.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [x] refactor
- [ ] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
