### PR TITLE
chore(branching): prepare migration to single main branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,12 +3,12 @@ name: PR checks
 on:
   push:
     branches:
+      - main
       - master
-      - ep2pl
   pull_request:
     branches:
+      - main
       - master
-      - ep2pl
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
     branches:
+      - main
       - master
-      - ep2pl
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EPUB Translator Studio
 
-[![PR checks](https://github.com/piotrgrechuta-web/epub-translator-studio/actions/workflows/pr-checks.yml/badge.svg?branch=master)](https://github.com/piotrgrechuta-web/epub-translator-studio/actions/workflows/pr-checks.yml)
+[![PR checks](https://github.com/piotrgrechuta-web/epub-translator-studio/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/piotrgrechuta-web/epub-translator-studio/actions/workflows/pr-checks.yml)
 [![Release](https://img.shields.io/github/v/release/piotrgrechuta-web/epub-translator-studio?display_name=tag)](https://github.com/piotrgrechuta-web/epub-translator-studio/releases)
 [![License: Personal Use Only](https://img.shields.io/badge/license-Personal%20Use%20Only-red.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](project-tkinter/app_main.py)

--- a/docs/01-Quick-Start.md
+++ b/docs/01-Quick-Start.md
@@ -17,7 +17,7 @@ Ta sekcja daje minimalna sciezke uruchomienia aplikacji Tkinter (glowna aplikacj
 ```powershell
 git clone https://github.com/piotrgrechuta-web/epub-translator-studio.git
 cd epub-translator-studio
-git checkout ep2pl
+git checkout main
 git pull
 ```
 

--- a/docs/03-Praca-na-2-komputerach.md
+++ b/docs/03-Praca-na-2-komputerach.md
@@ -3,7 +3,7 @@
 ## Model pracy
 
 Najprostszy i najbezpieczniejszy model:
-- jedna aktywna galaz robocza: `ep2pl`,
+- jedna aktywna galaz robocza: `main`,
 - zawsze `pull` przed praca,
 - zawsze `push` po zakonczonej sesji.
 
@@ -12,7 +12,7 @@ Najprostszy i najbezpieczniejszy model:
 ### Start sesji
 
 ```powershell
-git checkout ep2pl
+git checkout main
 git pull --rebase
 ```
 
@@ -59,7 +59,7 @@ Jesli chcesz wyrownac lokalne repo do zdalnego i zachowac kopie zmian:
 ```powershell
 git stash push -u -m "backup"
 git fetch origin
-git reset --hard origin/ep2pl
+git reset --hard origin/main
 git clean -fd
 ```
 

--- a/docs/05-CI-CD-i-Jakosc.md
+++ b/docs/05-CI-CD-i-Jakosc.md
@@ -7,8 +7,8 @@
 Plik: `.github/workflows/pr-checks.yml`
 
 Uruchamia sie na:
-- `push` do `master` i `ep2pl`,
-- `pull_request` do `master` i `ep2pl`,
+- `push` do `main` (oraz tymczasowo `master` w trakcie migracji),
+- `pull_request` do `main` (oraz tymczasowo `master` w trakcie migracji),
 - recznie (`workflow_dispatch`).
 
 Sprawdza:
@@ -27,7 +27,7 @@ Wymusza jakosc opisu PR:
 
 ## 5.2. Ochrona galezi
 
-Aktywna na `master` i `ep2pl`:
+Aktywna docelowo na `main`:
 - PR wymagany,
 - minimum 1 approval,
 - status checks wymagane,

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Uklad jest przygotowany tak, aby mozna go:
 
 ## Status
 
-- Branch protection: aktywna na `master` i `ep2pl`
+- Branch protection: aktywna na `main`
 - Required checks: `python-checks`, `validate-pr-body`
 - PR template: wymusza wypelnione sekcje i checkliste
 - Dokumentacja online (GitHub Pages): `https://piotrgrechuta-web.github.io/epub-translator-studio/`

--- a/project-tkinter/GIT_WORKFLOW_PL.md
+++ b/project-tkinter/GIT_WORKFLOW_PL.md
@@ -26,33 +26,33 @@ Dodatkowo skrypt ustawia **dual-push**:
 ## 2. Start pracy (zawsze przed edycja)
 
 ```powershell
-python scripts/git_workflow.py start --branch ep2pl
+python scripts/git_workflow.py start --branch main
 ```
 
 Skrypt zrobi:
 1. `git fetch --prune origin`
-2. `git switch ep2pl`
-3. `git pull --ff-only origin ep2pl`
+2. `git switch main`
+3. `git pull --ff-only origin main`
 
 Czyli masz aktualna wersje online, bez merge-ow przypadkowych.
 
 ## 3. Koniec pracy (publikacja)
 
 ```powershell
-python scripts/git_workflow.py publish --branch ep2pl -m "Twoj opis zmian"
+python scripts/git_workflow.py publish --branch main -m "Twoj opis zmian"
 ```
 
 Skrypt zrobi:
 1. `fetch` + `switch`
-2. sprawdzenie czy nie jestes za `origin/ep2pl`
+2. sprawdzenie czy nie jestes za `origin/main`
 3. `git add -A`
 4. `git commit -m "..."`
-5. `git push origin ep2pl` (po `setup`: automatycznie na `origin` i `backup`)
+5. `git push origin main` (po `setup`: automatycznie na `origin` i `backup`)
 
 ## 4. Szybki podglad statusu
 
 ```powershell
-python scripts/git_workflow.py status --branch ep2pl --fetch
+python scripts/git_workflow.py status --branch main --fetch
 ```
 
 ## 5. Minimalny rytm dnia

--- a/project-tkinter/MANUAL_PL.md
+++ b/project-tkinter/MANUAL_PL.md
@@ -665,8 +665,8 @@ W repo jest gotowa automatyzacja:
 
 Najkrotsza wersja:
 1. raz na komputer: `python scripts/git_workflow.py setup`
-2. start dnia: `python scripts/git_workflow.py start --branch ep2pl`
-3. publikacja: `python scripts/git_workflow.py publish --branch ep2pl -m "opis zmian"`
+2. start dnia: `python scripts/git_workflow.py start --branch main`
+3. publikacja: `python scripts/git_workflow.py publish --branch main -m "opis zmian"`
 
 ## 13. Wsparcie projektu
 

--- a/project-tkinter/scripts/git_workflow.py
+++ b/project-tkinter/scripts/git_workflow.py
@@ -189,16 +189,16 @@ def build_parser() -> argparse.ArgumentParser:
     ps.set_defaults(func=cmd_setup)
 
     pst = sub.add_parser("start", help="Start dnia: fetch + switch + pull --ff-only.")
-    pst.add_argument("--branch", default="ep2pl", help="Nazwa brancha roboczego (domyslnie: ep2pl).")
+    pst.add_argument("--branch", default="main", help="Nazwa brancha roboczego (domyslnie: main).")
     pst.set_defaults(func=cmd_start)
 
     pp = sub.add_parser("publish", help="Publikacja: add + commit + push.")
-    pp.add_argument("--branch", default="ep2pl", help="Nazwa brancha roboczego (domyslnie: ep2pl).")
+    pp.add_argument("--branch", default="main", help="Nazwa brancha roboczego (domyslnie: main).")
     pp.add_argument("-m", "--message", required=True, help="Wiadomosc commitu.")
     pp.set_defaults(func=cmd_publish)
 
     pss = sub.add_parser("status", help="Szybki status + ahead/behind.")
-    pss.add_argument("--branch", default="ep2pl", help="Branch referencyjny origin (domyslnie: ep2pl).")
+    pss.add_argument("--branch", default="main", help="Branch referencyjny origin (domyslnie: main).")
     pss.add_argument("--fetch", action="store_true", help="Najpierw wykonaj fetch --prune origin.")
     pss.set_defaults(func=cmd_status)
 


### PR DESCRIPTION
## Opis zmian

- przygotowano repo do przejscia na jedna galaz `main` (workflow i dokumentacja).
- workflowy CI/PR description uruchamiaja sie dla `main` oraz tymczasowo `master` (okres migracji).
- instrukcje i skrypty git-workflow zmienione z `ep2pl` na `main` jako domyslna galaz robocza.
- zaktualizowano badge README na `main`.

## Powod zmiany

- uproszczenie modelu pracy: jedna dobrze nazwana galaz produkcyjna zamiast `master + ep2pl`.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [x] CI/CD
- [x] refactor
- [ ] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

Wykonane:
- `python -m py_compile project-tkinter/scripts/git_workflow.py project-tkinter/app_main.py project-tkinter/app_gui_classic.py project-tkinter/app_gui_horizon.py project-tkinter/start.py project-tkinter/start_horizon.py`
- `python project-tkinter/scripts/smoke_gui.py` (`GUI_SMOKE_OK`)
- grep referencji branchy: brak aktywnych odniesien do `ep2pl` w instrukcjach/skryptach.

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
