### PR TITLE
chore(ci): finalize single-branch main workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, edited, reopened, synchronize, ready_for_review]
     branches:
       - main
-      - master
 
 permissions:
   contents: read

--- a/docs/05-CI-CD-i-Jakosc.md
+++ b/docs/05-CI-CD-i-Jakosc.md
@@ -7,8 +7,8 @@
 Plik: `.github/workflows/pr-checks.yml`
 
 Uruchamia sie na:
-- `push` do `main` (oraz tymczasowo `master` w trakcie migracji),
-- `pull_request` do `main` (oraz tymczasowo `master` w trakcie migracji),
+- `push` do `main`,
+- `pull_request` do `main`,
 - recznie (`workflow_dispatch`).
 
 Sprawdza:


### PR DESCRIPTION
## Opis zmian

- finalizacja migracji workflow do jedynej galezi `main`.
- usunieto przejsciowe odniesienia do `master` w triggerach workflow.
- doprecyzowano dokumentacje CI pod model single-branch.

## Powod zmiany

- po renamie galezi domyslnej `master -> main` triggerowanie workflow ma byc jednoznaczne i proste.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [x] CI/CD
- [x] refactor
- [ ] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

Wykonane:
- `python -m py_compile project-tkinter/scripts/git_workflow.py`
- `python project-tkinter/scripts/smoke_gui.py` (`GUI_SMOKE_OK`)
- grep branchy w sledzonych plikach: brak operacyjnych referencji do `master`/`ep2pl`.

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
