### PR TITLE
docs(seo): strengthen EPUB translator phrasing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 Language: **English** | [Polski](README.pl.md) | [Deutsch](README.de.md) | [Espanol](README.es.md) | [Francais](README.fr.md) | [Portugues](README.pt.md)
 
-Desktop toolkit for translating and editing EPUB files with AI.
+EPUB translator desktop app for AI-powered translation, post-editing, and QA of EPUB files.
 
-KEYWORDS: `EPUB translator`, `EPUB translation tool`, `AI translation`, `ebook translator`, `Ollama translator`, `Google Gemini translation`, `Translation Memory`, `QA gate`, `Tkinter`, `Python`.
+KEYWORDS: `EPUB translator`, `EPUB translator desktop app`, `EPUB translation tool`, `AI translation`, `ebook translator`, `Ollama translator`, `Google Gemini translation`, `Translation Memory`, `QA gate`, `Tkinter`, `Python`.
 
 ## What it does
 - EPUB translation (`translate`) and post-editing (`edit`)


### PR DESCRIPTION
## Opis zmian

- doprecyzowano opening copy README pod fraze exact-match `EPUB translator`.
- dodano wariant frazy `EPUB translator desktop app` do sekcji keywords.

## Powod zmiany

- poprawa trafnosci SEO na zapytanie `EPUB translator` przy zachowaniu naturalnego opisu produktu.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [x] refactor
- [ ] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji

Wykonane:
- kontrola diff `README.md`.
- weryfikacja, ze linki/badges pozostaja bez zmian funkcjonalnych.

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
