### PR TITLE
docs(roadmap): update M4-M7 milestones and backlog

### DIFF
--- a/docs/07-Roadmapa-i-kontrybucje.md
+++ b/docs/07-Roadmapa-i-kontrybucje.md
@@ -2,17 +2,17 @@
 
 ## 7.1. Priorytety techniczne
 
-1. Stabilnosc runtime i redukcja edge-case crashy.
-2. Lepsze testy automatyczne backend + UI smoke.
-3. Lepsza ergonomia pracy na dwoch komputerach.
-4. Uporzadkowanie danych lokalnych (cache/db/lock).
+1. Integralnosc EPUB po tlumaczeniu (tagi inline, encje, `&shy;`).
+2. Diff-aware retranslation zamiast pelnego rerunu ksiazki.
+3. Kontekst translacji i spojnosc encji/postaci.
+4. QA jezykowe pod redakcje polszczyzny.
 
 ## 7.2. Priorytety produktowe
 
-1. Przejrzystosc workflow translacja -> QA -> publish.
-2. Lepsza konfiguracja providerow i modeli.
-3. Silniejsza dokumentacja onboardingowa.
-4. Bardziej czytelne komunikaty bledow.
+1. Workflow "tlumacz -> czytaj -> popraw -> wznow".
+2. Widoczny status projektu i etapow bez watpliwosci "co dalej".
+3. Spojnosc stylu miedzy tomami jednej serii.
+4. Lepsza dokumentacja onboardingowa i recovery.
 
 ## 7.3. Jak zglaszac zmiany
 
@@ -55,3 +55,13 @@ Jesli projekt oszczedza czas:
 - krotszy czas od bug report do fix,
 - mniejsza liczba problemow z konfiguracja,
 - szybszy onboarding nowego urzadzenia.
+
+## 7.8. Kolejne milestone'y (po M1-M3)
+
+1. `M4: Context-Aware Translation`
+2. `M5: Text Integrity + Diff-Retranslation`
+3. `M6: Polish QA + Live Reading Loop`
+4. `M7: Batch Library + Style Memory`
+
+Zakres i kryteria `Done` sa utrzymywane w:
+- `docs/09-Backlog-do-uzgodnienia.md`

--- a/docs/09-Backlog-do-uzgodnienia.md
+++ b/docs/09-Backlog-do-uzgodnienia.md
@@ -3,17 +3,23 @@
 Status:
 - `M1 wdrozone` w kodzie i dokumentacji (2026-02-08),
 - `M2 wdrozone` w kodzie i CI (2026-02-08),
-- `M3 czesciowo wdrozone`: Issue 8 i 9 `zrealizowane`, Issue 7 `w toku` (inicjalizacja Wiki backend).
+- `M3 w toku`: Issue 8 i 9 `zrealizowane`, Issue 7 `do domkniecia` (inicjalizacja Wiki backend),
+- `M4 plan zatwierdzony`: kontekst tlumaczenia + spojnosc postaci,
+- `M5 plan zatwierdzony`: ochrona tekstu (`&shy;`) + diff-aware retranslation,
+- `M6 plan zatwierdzony`: QA polszczyzny + tryb czytaj/tlumacz/wroc,
+- `M7 plan zatwierdzony`: batch library + pamiec stylu serii.
 
 ## Cel
 
 Zamienic roadmape na konkretne, mierzalne zadania z jasnym zakresem i kryteriami akceptacji.
 
-## Proponowane milestone'y
+## Aktywne milestone'y
 
-1. `M1: UI Consistency + UX Telemetry`
-2. `M2: CI Hardening + Test Coverage`
-3. `M3: Workflow + Docs + Wiki`
+1. `M3: Workflow + Docs + Wiki (domkniecie)`
+2. `M4: Context-Aware Translation`
+3. `M5: Text Integrity + Diff-Retranslation`
+4. `M6: Polish QA + Live Reading Loop`
+5. `M7: Batch Library + Style Memory`
 
 ## M1: UI Consistency + UX Telemetry
 
@@ -82,7 +88,7 @@ Status M3: `w toku` (2/3 issue zamkniete).
 - Done:
   - `/wiki` dziala bez przekierowania na strone repo,
   - wiki ma minimum 1 strone i sidebar.
-  
+
 Status: `w toku` (backend Wiki wymaga inicjalizacji pierwszej strony `Home`).
 
 ### Issue 8: Release checklist i changelog discipline
@@ -103,14 +109,98 @@ Status: `zrealizowane`.
 
 Status: `zrealizowane`.
 
-## Kolejnosc realizacji (propozycja)
+## M4: Context-Aware Translation
 
-1. M1 (widoczne efekty dla uzytkownika od razu)
-2. M2 (stabilnosc i bezpieczenstwo procesu wydawniczego)
-3. M3 (dokumentacja, wiki, release discipline)
+Status M4: `plan`.
 
-## Pytania do zatwierdzenia przed publikacja Issues
+### Issue 10: Kontekst poza segmentem
+- Zakres:
+  - przekazywanie okna kontekstu (poprzedni/nastepny segment, tytul rozdzialu) do promptu,
+  - konfiguracja dlugosci kontekstu per run.
+- Done:
+  - mniej bledow typu "kim jest she/he" w dialogach bez znacznikow speakera,
+  - testy parsera potwierdzaja brak regresji tagow inline.
 
-1. Czy publikujemy wszystkie 9 issue od razu, czy tylko M1 jako sprint 1?
-2. Czy chcesz etykiety (`ui`, `backend`, `ci`, `docs`, `priority-high`)?
-3. Czy milestone'y ustawic na daty, czy bez dat (rolling)?
+### Issue 11: Pamiec encji i spojnosci postaci
+- Zakres:
+  - lekka pamiec encji (imiona, aliasy, relacje) na poziomie ksiazki,
+  - automatyczne flagi QA przy zmianie nazwy postaci bez uzasadnienia.
+- Done:
+  - raport niespojnosci nazw po runie,
+  - mozliwosc zatwierdzenia kanonicznej formy w UI.
+
+## M5: Text Integrity + Diff-Retranslation
+
+Status M5: `plan`.
+
+### Issue 12: Ochrona hyphenation i `&shy;`
+- Zakres:
+  - zachowanie `&shy;`/nbsp i krytycznych encji typograficznych podczas translacji i redakcji,
+  - walidator integralnosci znakow specjalnych.
+- Done:
+  - brak utraty `&shy;` po translacji,
+  - testy automatyczne porownuja liczbe i pozycje kluczowych encji.
+
+### Issue 13: Diff-aware retranslation
+- Zakres:
+  - retranslacja tylko zmienionych segmentow po poprawce zrodla,
+  - opcjonalna retranslacja sasiedztwa (N segmentow) dla spojnosci.
+- Done:
+  - raport: `changed/reused/retranslated`,
+  - brak potrzeby pelnej retranslacji po drobnych poprawkach.
+
+## M6: Polish QA + Live Reading Loop
+
+Status M6: `plan`.
+
+### Issue 14: Walidacja polszczyzny specyficznej
+- Zakres:
+  - zestaw regulek QA (liczebniki, przypadki, kolokacje stylu literackiego),
+  - klasyfikacja findings: `info/warn/error`.
+- Done:
+  - lista findings z podpowiedzia korekty,
+  - eksport raportu QA dla redakcji.
+
+### Issue 15: Tryb "tlumaczenie na zywo podczas czytania"
+- Zakres:
+  - workflow: tlumacz fragment -> czytaj na czytniku -> wznow od punktu,
+  - checkpointy per rozdzial i per run.
+- Done:
+  - wznowienie bez utraty historii i cache,
+  - w UI widac, ktore fragmenty sa "po lekturze" i "do poprawy".
+
+## M7: Batch Library + Style Memory
+
+Status M7: `plan`.
+
+### Issue 16: Profile stylu serii
+- Zakres:
+  - profile stylu i tonu reuzywalne miedzy ksiazkami,
+  - mapowanie projektu do profilu stylu.
+- Done:
+  - profil stylu mozna przypisac i eksportowac/importowac,
+  - nowy projekt moze dziedziczyc styl poprzednich tomow.
+
+### Issue 17: Batch library z pamiecia stylu
+- Zakres:
+  - kolejkowanie wielu ksiazek ze wspolnym stylem i pamiecia encji,
+  - globalny panel postepu biblioteki + postep per ksiazka.
+- Done:
+  - uruchomienie wsadowe wielu EPUB w jednym runie,
+  - raport koncowy porownuje jakosc i spojnosc miedzy tomami.
+
+## Kolejnosc realizacji (zaktualizowana)
+
+1. Domkniecie `M3 / Issue 7` (Wiki backend + Home + sidebar).
+2. `M5` (najszybszy zysk produkcyjny: `&shy;` + diff-aware).
+3. `M4` (kontekst i spojnosc postaci).
+4. `M6` (QA jezykowe + loop czytelniczy).
+5. `M7` (tryb serii i batch library).
+
+## Definicja publikacji milestone
+
+Milestone publikujemy jako "gotowy do realizacji", gdy:
+1. kazde issue ma zakres + kryteria `Done`,
+2. kazde issue ma etykiete i priorytet,
+3. jest podana kolejnosc wdrozenia (co first, co later),
+4. zespol zna zaleznosci miedzy issue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Uklad jest przygotowany tak, aby mozna go:
 6. [Troubleshooting](06-Troubleshooting.md)
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
 8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
+9. [Backlog i milestone](09-Backlog-do-uzgodnienia.md)
 
 ## Dokumenty zrodlowe
 


### PR DESCRIPTION
## Opis zmian
Zaktualizowano roadmape i backlog milestone'ow. W `docs/09` dodano nowe M4-M7 (kontekst, spojnosc encji, ochrona `&shy;`, diff-aware retranslation, QA polszczyzny, tryb czytaj/tlumacz/wznow i batch library). W `docs/07` dostosowano priorytety techniczne/produktowe i dodano sekcje kolejnych milestone'ow. W `docs/README` dodano link do backlogu milestone.

## Powod zmiany
Po uzgodnieniu kierunku rozwoju potrzebny byl jednoznaczny plan prac po M1-M3 oraz publikacja tych etapow na GitHubie. Bez tej aktualizacji roadmapa i backlog byly niezsynchronizowane z faktycznymi priorytetami produktu.

## Jak testowano
- [x] Weryfikacja diff: `git diff -- docs/07-Roadmapa-i-kontrybucje.md docs/09-Backlog-do-uzgodnienia.md docs/README.md`
- [x] Weryfikacja publikacji milestones/issues przez `gh api` i `gh issue list`
- [x] Sprawdzenie, ze otwarte milestone i issue sa przypiete do poprawnych etapow M3-M7

## Lista kontrolna
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
