### PR TITLE
Add edit/delete series management

### DIFF
--- a/project-tkinter/MANUAL_PL.md
+++ b/project-tkinter/MANUAL_PL.md
@@ -192,6 +192,21 @@ Po udanym runie aplikacja moze dopisac propozycje terminow serii na podstawie TM
 1. tworzy rekord w tabeli `series` (`translator_studio.db`),
 2. inicjalizuje lokalny magazyn `data/series/<slug>/series.db`.
 
+### `Edytuj serie`
+- Po co: zmiana nazwy serii bez przepinania projektow.
+- Jak: wybierz serie z listy, klik `Edytuj serie`, wpisz nowa nazwe.
+- Wplyw:
+1. aktualizuje nazwe w tabeli `series`,
+2. zachowuje przypisania projektow do tej serii.
+
+### `Usun serie`
+- Po co: usuniecie serii, gdy nie chcesz juz jej utrzymywac.
+- Jak: wybierz serie z listy i klik `Usun serie`.
+- Wplyw:
+1. usuwa rekord serii z `translator_studio.db`,
+2. automatycznie odpina wszystkie projekty od tej serii (`series_id=NULL`, `volume_no=NULL`),
+3. opcjonalnie usuwa lokalne dane serii z `data/series/<slug>/`.
+
 ### `Auto z EPUB`
 - Po co: automatyczne podpowiedzenie serii na podstawie metadanych EPUB (`OPF`).
 - Jak: po ustawieniu `Wejsciowy EPUB` kliknij `Auto z EPUB` i potwierdz przypisanie.
@@ -595,6 +610,8 @@ Typowy flow:
 | `Zapisz` | nic | `projects` update |
 | `Nowy` | nic | nowy rekord `projects` |
 | `Nowa seria` | tworzy `data/series/<slug>/series.db` | nowy rekord `series` |
+| `Edytuj serie` | aktualizuje metadane serii | update rekordu `series` |
+| `Usun serie` | opcjonalnie usuwa `data/series/<slug>/` | usuwa rekord `series`, odpina `projects.series_id` |
 | `Auto z EPUB` | nic | przypisuje `projects.series_id` i opcjonalnie `projects.volume_no` |
 | `Slownik serii` (approve/reject/add) | aktualizuje pliki pod `data/series/<slug>/` | zapis terminow/decydji w bazie serii (osobny SQLite) |
 | `Kolejkuj` | nic | status `projects` -> `pending` |


### PR DESCRIPTION
## Opis zmian
- dodano zarzadzanie seria w GUI: przyciski `Edytuj serie` i `Usun serie` na karcie projektu
- dodano logike backendu w `ProjectDB`: `count_projects_for_series`, `update_series`, `delete_series`
- usuwanie serii odpina powiazane projekty (`series_id=NULL`, `volume_no=NULL`) i moze opcjonalnie usuwac lokalne dane serii z `data/series/<slug>/`
- przy braku serii `volume_no` jest zapisywane jako `NULL`, zeby nie zostawac osierocone wartosci tomu
- manual PL uzupelniono o flow `Edytuj serie`/`Usun serie`
- dodano test regresyjny update+delete serii i odpinania projektow

## Powod zmiany
Uzytkownik potrzebuje kompletnego zarzadzania seria bez wychodzenia do SQL: sama opcja tworzenia nie wystarcza operacyjnie. Brak edycji/usuwania powodowal narastanie blednych wpisow i reczna ingerencje w baze.

## Jak testowano
- [x] `python -m py_compile project-tkinter/project_db.py project-tkinter/app_gui_classic.py project-tkinter/tests/test_series_support.py`
- [x] `python -m pytest -q project-tkinter/tests`
- [x] `python project-tkinter/scripts/smoke_gui.py`

## Lista kontrolna
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje opisu PR.
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia.
- [ ] Nie dotyczy (ta zmiana nie dodaje nowych funkcji).