### PR TITLE
M7 complete: series memory/batch + DB version alias + repository layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,19 @@ EPUB translator desktop app for AI-powered translation, post-editing, and QA of 
 
 KEYWORDS: `EPUB translator`, `EPUB translator desktop app`, `EPUB translation tool`, `AI translation`, `ebook translator`, `Ollama translator`, `Google Gemini translation`, `Translation Memory`, `QA gate`, `Tkinter`, `Python`.
 
-## What it does
+## Unique strengths (not common in most EPUB tools)
+- idempotent processing with segment ledger (`done/processing/error/pending`) and safe resume after interruption
+- managed DB migrations with backup + rollback (`migration_runs`, startup recovery notice, DB Update panel)
+- security-first runtime gates (EPUBCheck hard gate + QA severity gate)
+- Smart Context window for neighboring segments (better pronouns/gender consistency)
+- Series Memory engine: per-series terms, style rules, lorebook, change history, series profile import/export
+- one-click series batch orchestration with aggregated series report (`series_batch_report_*.json/.md`)
+
+## Core capabilities you also get (industry-standard set)
 - EPUB translation (`translate`) and post-editing (`edit`)
 - EPUB validation
 - Translation Memory (TM) and segment cache
-- always-visible ledger progress strip in Run panel (`done/processing/error/pending`)
-- model-specific prompt presets in GUI (Gemini: `Book Balanced`, `Lovecraft Tone`, `Technical Manual`, `Polish Copyedit`)
+- model-specific prompt presets in GUI
 - QA findings workflow and QA gate
 - EPUB operations: front card, cover/image removal, segment editor
 - project queue workflow (`pending`, `run all`)
@@ -86,6 +93,7 @@ export GOOGLE_API_KEY="<YOUR_KEY>"
 - canonical translator: `project-tkinter/translation_engine.py`
 - both UI variants (`classic`, `horizon`) run on the same core/runtime contracts
 - prompt preset catalog: `project-tkinter/prompt_presets.json`
+- state-store abstraction layer (Repository step): `project-tkinter/studio_repository.py`
 
 ## Documentation
 - Tkinter user manual (PL): `project-tkinter/MANUAL_PL.md`

--- a/README.pl.md
+++ b/README.pl.md
@@ -7,12 +7,19 @@ Desktopowy zestaw narzedzi do tlumaczenia i redakcji plikow EPUB z AI.
 KEYWORDS: `tlumacz EPUB`, `narzedzie do tlumaczenia EPUB`, `tlumaczenie AI`, `tlumacz ebookow`, `Ollama`, `Google Gemini`, `Translation Memory`, `QA gate`, `Tkinter`, `Python`.
 
 
-## Co to robi
+## Unikalne cechy (rzadko spotykane w narzedziach EPUB)
+- idempotentny pipeline z ledgerem segmentow (`done/processing/error/pending`) i bezpiecznym resume po awarii
+- zarzadzane migracje bazy z backupem i rollbackiem (`migration_runs`, startup notice, panel DB Update)
+- security-first gate'y runtime (twardy EPUBCheck + QA severity gate)
+- Smart Context (segmenty sasiednie) dla lepszej spojnosci form i odniesien
+- Series Memory: termy serii, style rules, lorebook, historia zmian, import/export profilu serii
+- orkiestracja batcha serii jednym kliknieciem + raport zbiorczy (`series_batch_report_*.json/.md`)
+
+## Cechy standardowe projektu (jak w dobrych narzedziach klasy pro)
 - tlumaczenie EPUB (`translate`) i redakcja (`edit`)
 - walidacja EPUB
 - Translation Memory (TM) i cache segmentow
-- staly mini-dashboard ledgera w sekcji `Uruchomienie` (`done/processing/error/pending`)
-- presety promptow w GUI pod provider/model (Gemini: `Book Balanced`, `Lovecraft Tone`, `Technical Manual`, `Polish Copyedit`)
+- presety promptow w GUI pod provider/model
 - workflow findings QA i QA gate
 - operacje EPUB: wizytowka, usuwanie okladki/grafik, edytor segmentow
 - praca kolejka projektow (`pending`, `run all`)
@@ -82,6 +89,7 @@ export GOOGLE_API_KEY="<TWOJ_KLUCZ>"
 - kanoniczny translator: `project-tkinter/translation_engine.py`
 - oba warianty UI (`classic`, `horizon`) korzystaja z tej samej logiki runtime
 - katalog presetow promptow: `project-tkinter/prompt_presets.json`
+- warstwa abstrakcji state-store (krok Repository): `project-tkinter/studio_repository.py`
 
 ## Dokumentacja
 - manual uzytkownika Tkinter (PL): `project-tkinter/MANUAL_PL.md`

--- a/docs/07-Roadmapa-i-kontrybucje.md
+++ b/docs/07-Roadmapa-i-kontrybucje.md
@@ -5,7 +5,7 @@
 - `M1`: zrealizowane.
 - `M2`: zrealizowane.
 - `M3`: zamrozone (blokada po stronie GitHub Wiki; bez wpływu na runtime aplikacji).
-- `M7`: uruchomiony szkielet techniczny (seria + slownik serii + auto-detekcja + merge glosariusza).
+- `M7`: domkniete (series manager: termy + style rules + lorebook + historia zmian, prompt augmentation kontekstem serii, orchestrator batch serii z raportem).
 - `M4`: domkniete (ledger orchestration upfront + twardy gate EPUBCheck + tokenized inline editor + dashboard ledger metrics + stale widoczny pasek ledgera + presety promptow Gemini w GUI + telemetry retry/timeout + export metryk do release notes + alert progowy ledgera).
 - `M5`: domkniete (nested-inline chips w edytorze + dodatkowe testy regresji + walidator integralnosci `&shy;/&nbsp;` z raportem po runie).
 - `M6`: domkniete (diff-aware retranslation + semantic diff gate + raport changed/reused/retranslated + auto-findings QA).
@@ -74,10 +74,11 @@ Jesli projekt oszczedza czas:
 - mniejsza liczba problemow z konfiguracja,
 - szybszy onboarding nowego urzadzenia.
 
-## 7.8. Kolejne milestone'y (po M1-M2, M3 zamrozone)
+## 7.8. Kolejne milestone'y (po M1-M2, M3 zamrozone, M4-M7 domkniete)
 
-1. `M4: Memory-First Translation Engine`
-2. `M7: Series Style Memory + Batch Library` (foundation active, kolejne incrementy w backlogu)
+1. Stabilizacja i utrzymanie M4-M7 (bugfixy + ergonomia).
+2. Odmrozenie `M3 / Wiki` po odblokowaniu backendu GitHub Wiki.
+3. Kolejny increment funkcjonalny po uzgodnieniu backlogu.
 
 Zakres i kryteria `Done` sa utrzymywane w:
 - `docs/09-Backlog-do-uzgodnienia.md`

--- a/docs/09-Backlog-do-uzgodnienia.md
+++ b/docs/09-Backlog-do-uzgodnienia.md
@@ -7,7 +7,7 @@ Status:
 - `M4 domkniete`: memory-first translation (cache + decision memory + adaptive prompting), z domknietymi metrykami ledgera/retry/timeout i eksportem release notes,
 - `M5 zrealizowane`: EPUB-aware segmentacja i integralnosc markup (`&shy;`, inline tags),
 - `M6 zrealizowane`: diff-aware retranslation + semantic diff gate do recenzji,
-- `M7 w realizacji`: wdrozony szkielet serii (project->series, baza serii, manager terminow, merge glosariusza).
+- `M7 domkniete`: pelny series manager (termy + style rules + lorebook + historia), prompt augmentation kontekstem serii, orchestrator batch serii + raport.
 
 ## Cel
 
@@ -15,11 +15,8 @@ Zamienic roadmape na konkretne, mierzalne zadania z jasnym zakresem i kryteriami
 
 ## Aktywne milestone'y
 
-1. `M4: Memory-First Translation Engine`
-2. `M3: Workflow + Docs + Wiki (zamrozone)`
-3. `M5: EPUB-Aware Segmentation + Markup Integrity`
-4. `M6: Smart Retranslation + Semantic Diff QA`
-5. `M7: Series Style Memory + Batch Library`
+1. `M3: Workflow + Docs + Wiki (zamrozone)`
+2. Utrzymanie i stabilizacja M4-M7
 
 ## M1: UI Consistency + UX Telemetry
 
@@ -226,7 +223,7 @@ Status: `zrealizowane`:
 
 ## M7: Series Style Memory + Batch Library
 
-Status M7: `w realizacji` (foundation deployed).
+Status M7: `zrealizowane`.
 
 ### Issue #31: Profile stylu serii (tone memory)
 - Zakres:
@@ -239,15 +236,14 @@ Status M7: `w realizacji` (foundation deployed).
   - widoczna poprawa spojnosci stylu miedzy tomami.
 
 Status:
-- `szkielet wdrozony`:
+- `zrealizowane`:
 1. projekty maja `series_id` i `volume_no`,
 2. autodetekcja serii z metadanych EPUB (`OPF`),
 3. osobna baza serii (`data/series/<slug>/series.db`),
-4. panel `Slownik serii` (approve/reject/manual add),
-5. merge slownika serii z glosariuszem projektu na etapie runu.
-- `do domkniecia`:
-1. UI/DB dla jawnych "style rules" i "lorebook" per seria,
-2. wersjonowanie profili stylu (diff + historia zmian).
+4. panel `Series manager` (termy + `style_rules` + `lorebook` + historia zmian `change_log`),
+5. merge slownika serii z glosariuszem projektu na etapie runu,
+6. prompt augmentowany automatycznie kontekstem serii (style/lore/approved terms),
+7. import/export profilu serii (`series_profile.json`).
 
 ### Issue #32: Batch library + opcjonalny tor LoRA/QLoRA
 - Zakres:
@@ -260,14 +256,18 @@ Status:
   - dokumentacja oddziela tryb produkcyjny od eksperymentalnego fine-tuning.
 
 Status:
-- `plan` (brak wdrozenia wsadowego orchestratora biblioteki serii).
+- `zrealizowane`:
+1. orchestrator batch serii (queue po serii dla biezacego kroku `translate/edit`),
+2. uruchamianie run-all dla serii jednym kliknieciem,
+3. raport zbiorczy serii (`series_batch_report_*.json/.md`) z postepem i statusem projektow.
+- `poza zakresem M7`:
+1. eksperymentalny tor LoRA/QLoRA pozostaje opcjonalnym backlogiem R&D.
 
 ## Kolejnosc realizacji (zaktualizowana)
 
 1. `M4` utrzymanie i stabilizacja po wdrozeniu.
-2. Domkniecie `M7 / Issue 31` (style rules + lorebook + versioning).
-3. `M7 / Issue 32` (skalowanie batch + opcjonalny fine-tuning).
-4. `M3 / Issue 7` (Wiki backend + Home + sidebar) dopiero po odmrozeniu.
+2. `M7` utrzymanie i ergonomia po wdrozeniu.
+3. `M3 / Issue 7` (Wiki backend + Home + sidebar) dopiero po odmrozeniu.
 
 ## Definicja publikacji milestone
 

--- a/docs/10-Series-Style-Memory.md
+++ b/docs/10-Series-Style-Memory.md
@@ -1,6 +1,8 @@
-# 10. Series Style Memory - szkielet techniczny
+# 10. Series Style Memory + Batch Library (M7)
 
-Dokument opisuje wdrozony fundament pod spojna prace na wielu ksiazkach jednej serii.
+Status: `domkniete` (2026-02-09).
+
+Dokument opisuje finalny zakres M7 po wdrozeniu warstwy stylu/lore i orchestratora batch serii.
 
 ## 10.1. Co zostalo wdrozone
 
@@ -14,33 +16,44 @@ Dokument opisuje wdrozony fundament pod spojna prace na wielu ksiazkach jednej s
 
 3. Per-seria magazyn danych:
 - `project-tkinter/data/series/<slug>/series.db`,
-- tabele: `terms`, `decisions`, `lore_entries`, `style_rules`.
+- tabele: `terms`, `decisions`, `lore_entries`, `style_rules`, `change_log`.
 
-4. UI:
-- wybor serii i tomu na karcie projektu,
-- przyciski: `Nowa seria`, `Auto z EPUB`, `Slownik serii`,
-- manager terminow (approve/reject/manual add/export).
+4. Series Manager (GUI):
+- zakladki: `Termy`, `Style rules`, `Lorebook`, `Historia`,
+- approve/reject terminow, manual add, learn from TM, eksport glosariusza,
+- edycja `style_rules` i `lore_entries`,
+- import/export profilu serii (`series_profile.json`),
+- historia zmian (audit/versioning) per wpis.
 
 5. Runtime:
-- przy runie budowany jest scalony glosariusz:
-  - zatwierdzone terminy serii,
-  - lokalny glosariusz projektu.
-- po udanym runie aplikacja uczy serie z TM projektu (status `proposed`).
+- przy runie budowany jest scalony glosariusz (seria + projekt),
+- prompt jest augmentowany kontekstem serii (style rules + active lore + approved terms),
+- po udanym runie TM projektu zasila propozycje terminow serii.
 
-6. Stabilnosc migracji:
-- samonaprawa schematu `project_db.py` dla baz z dryfem wersji
-  (np. `schema_version=8`, ale brak kolumn `series_id/volume_no`).
+6. Batch Library (seria):
+- queue calej serii dla kroku `translate` lub `edit`,
+- uruchomienie batch serii jednym kliknieciem (`Run series batch`),
+- raport zbiorczy serii `series_batch_report_*.json/.md`.
 
 ## 10.2. Dane i pliki
 
 - GLOWNA baza: `project-tkinter/translator_studio.db`
 - Baza serii: `project-tkinter/data/series/<slug>/series.db`
 - Eksport serii: `project-tkinter/data/series/<slug>/generated/approved_glossary.txt`
-- Run-specific merge: `project-tkinter/data/series/<slug>/generated/merged_glossary_project_<id>.txt`
+- Merge glosariusza per run: `project-tkinter/data/series/<slug>/generated/merged_glossary_project_<id>.txt`
+- Prompt augmentowany serii: `project-tkinter/data/series/<slug>/generated/prompt_<step>_project_<id>.txt`
+- Eksport profilu: `project-tkinter/data/series/<slug>/generated/series_profile.json`
+- Raport batch: `project-tkinter/data/series/<slug>/generated/series_batch_report_<timestamp>.json/.md`
 
-## 10.3. Co dalej (kolejne incrementy)
+## 10.3. Szybki workflow
 
-1. Jawny edytor `style_rules` i `lore_entries` w UI (M7/Issue 31).
-2. Versioning zmian slownika/stylu serii (audit + diff).
-3. Batch orchestrator dla wielu ksiazek jednej serii (M7/Issue 32).
-4. Integracja z M4: decision memory jako dynamic few-shot kontekst.
+1. Przypisz projekty do serii i ustaw `Tom`.
+2. Otworz `Slownik serii` (Series manager).
+3. Ustal `Style rules` i `Lorebook` (aktywny lore ustaw na `active`).
+4. Zatwierdz kluczowe terminy (`approved`).
+5. Uruchom `Run series batch` dla kroku `translate`, potem `edit`.
+6. Sprawdz raport `series_batch_report_*.md`.
+
+## 10.4. Zakres poza M7
+
+- Eksperymentalny tor LoRA/QLoRA pozostaje opcjonalnym backlogiem R&D.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Uklad jest przygotowany tak, aby mozna go:
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
 8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
 9. [Backlog i milestone](09-Backlog-do-uzgodnienia.md)
-10. [Series Style Memory - szkielet](10-Series-Style-Memory.md)
+10. [Series Style Memory + Batch Library](10-Series-Style-Memory.md)
 
 ## Dokumenty zrodlowe
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ To jest strona startowa dla GitHub Pages (`/docs`).
 7. [Roadmapa i kontrybucje](07-Roadmapa-i-kontrybucje.md)
 8. [Status UI i Wiki/Pages](08-Status-UI-i-Wiki.md)
 9. [Backlog i kolejne etapy](09-Backlog-do-uzgodnienia.md)
-10. [Series Style Memory - szkielet](10-Series-Style-Memory.md)
+10. [Series Style Memory + Batch Library](10-Series-Style-Memory.md)
 
 ## Zrodla
 

--- a/project-tkinter/MANUAL_PL.md
+++ b/project-tkinter/MANUAL_PL.md
@@ -413,9 +413,22 @@ Cel:
 Przebieg:
 1. Przypisz projekt do serii.
 2. Ustaw numer tomu.
-3. Po runie program moze zaproponowac terminy z TM.
-4. W `Slownik serii` zatwierdzaj terminy.
-5. Zatwierdzone terminy trafiaja do scalonego glosariusza kolejnych runow.
+3. Otworz `Slownik serii` (Series manager).
+4. Zakladka `Termy`:
+- approve/reject terminow,
+- `Learn from TM` aby zasolic propozycje z pamieci tlumaczen,
+- `Export glossary` dla zatwierdzonych terminow.
+5. Zakladka `Style rules`:
+- dodaj reguly stylu serii (tone, dialog, interpunkcja, narracja),
+- reguly sa dolaczane do promptu runu jako kontekst serii.
+6. Zakladka `Lorebook`:
+- dodaj fakty swiata i postaci,
+- status `active` oznacza, ze wpis idzie do kontekstu promptu.
+7. Zakladka `Historia`:
+- podglad audytu zmian (terms/style/lore),
+- sluzy jako wersjonowanie i szybki diff operacyjny.
+8. `Export/Import series profile`:
+- przenoszenie stylu/lore/approved terms miedzy seriami lub komputerami.
 
 ## 11. Kolejka projektow i praca seryjna
 
@@ -424,6 +437,12 @@ Scenariusz:
 2. Kliknij `Run all pending`.
 3. Program wykonuje projekty po kolei.
 4. `Stop run-all` zatrzyma po biezacym zadaniu.
+
+Scenariusz seryjny (M7):
+1. Wejdz w `Slownik serii`.
+2. Kliknij `Queue series (current step)`.
+3. Kliknij `Run series batch`.
+4. Po zakonczeniu sprawdz `Export series report` albo plik `series_batch_report_*.md`.
 
 Po nowej poprawce reliability:
 - jesli aplikacja padnie w trakcie runu, przy nast. starcie statusy `running` sa automatycznie naprawiane do stanu odzyskiwalnego.

--- a/project-tkinter/scripts/installer.iss
+++ b/project-tkinter/scripts/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "EPUB Translator Studio"
-#define MyAppVersion "0.5.0"
+#define MyAppVersion "0.6.0"
 #define MyAppPublisher "EPUB Translator Studio"
 #define MyAppExeName "EPUBTranslatorStudio.exe"
 

--- a/project-tkinter/series_store.py
+++ b/project-tkinter/series_store.py
@@ -18,6 +18,7 @@ from lxml import etree
 SERIES_DB_FILE = "series.db"
 APPROVED_GLOSSARY_FILE = "approved_glossary.txt"
 GENERATED_DIR = "generated"
+SERIES_PROFILE_FILE = "series_profile.json"
 
 
 def _now_ts() -> int:
@@ -225,6 +226,20 @@ class SeriesStore:
             )
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS change_log (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_key TEXT NOT NULL,
+              action TEXT NOT NULL,
+              payload_json TEXT NOT NULL DEFAULT '{}',
+              created_at INTEGER NOT NULL
+            )
+            """
+        )
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_change_log_created ON change_log(created_at DESC, id DESC)")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_change_log_entity ON change_log(entity_type, entity_key, created_at DESC)")
         conn.commit()
 
     def ensure_series_db(self, slug: str, *, display_name: str = "") -> Path:
@@ -246,6 +261,43 @@ class SeriesStore:
             )
             conn.commit()
         return self.series_db_path(clean_slug)
+
+    @staticmethod
+    def _json_dumps(payload: Any) -> str:
+        try:
+            return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            return json.dumps({"value": str(payload)}, ensure_ascii=False, sort_keys=True)
+
+    @staticmethod
+    def _json_loads(value: str, default: Any) -> Any:
+        try:
+            return json.loads(str(value or ""))
+        except Exception:
+            return default
+
+    def _log_change(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        entity_type: str,
+        entity_key: str,
+        action: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO change_log(entity_type, entity_key, action, payload_json, created_at)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                str(entity_type or "").strip(),
+                str(entity_key or "").strip(),
+                str(action or "").strip(),
+                self._json_dumps(payload),
+                _now_ts(),
+            ),
+        )
 
     def add_or_update_term(
         self,
@@ -296,8 +348,22 @@ class SeriesStore:
                         approved_at,
                     ),
                 )
+                term_id = int(cur.lastrowid)
+                self._log_change(
+                    conn,
+                    entity_type="term",
+                    entity_key=f"{src} => {dst}",
+                    action="create",
+                    payload={
+                        "term_id": term_id,
+                        "status": str(status),
+                        "confidence": float(confidence),
+                        "origin": str(origin or ""),
+                        "project_id": project_id,
+                    },
+                )
                 conn.commit()
-                return int(cur.lastrowid), True
+                return term_id, True
 
             current_status = str(row["status"] or "proposed")
             final_status = current_status
@@ -335,6 +401,19 @@ class SeriesStore:
                     int(row["id"]),
                 ),
             )
+            self._log_change(
+                conn,
+                entity_type="term",
+                entity_key=f"{src} => {dst}",
+                action="update",
+                payload={
+                    "term_id": int(row["id"]),
+                    "status": str(final_status),
+                    "confidence": float(final_conf),
+                    "origin": str(origin or ""),
+                    "project_id": project_id,
+                },
+            )
             conn.commit()
             return int(row["id"]), False
 
@@ -342,6 +421,10 @@ class SeriesStore:
         now = _now_ts()
         approved_at = now if status == "approved" else None
         with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT source_term, target_term FROM terms WHERE id = ?",
+                (int(term_id),),
+            ).fetchone()
             conn.execute(
                 """
                 UPDATE terms
@@ -351,6 +434,18 @@ class SeriesStore:
                 """,
                 (status, str(notes or ""), str(notes or ""), now, approved_at, int(term_id)),
             )
+            if row is not None:
+                self._log_change(
+                    conn,
+                    entity_type="term",
+                    entity_key=f"{str(row['source_term'] or '').strip()} => {str(row['target_term'] or '').strip()}",
+                    action="status",
+                    payload={
+                        "term_id": int(term_id),
+                        "status": str(status or ""),
+                        "notes": str(notes or ""),
+                    },
+                )
             conn.commit()
 
     def list_terms(self, slug: str, *, status: Optional[str] = None, limit: int = 300) -> List[sqlite3.Row]:
@@ -377,6 +472,496 @@ class SeriesStore:
                 (int(limit),),
             ).fetchall()
             return [(str(r["source_term"]), str(r["target_term"])) for r in rows]
+
+    def list_style_rules(self, slug: str, *, limit: int = 500) -> List[sqlite3.Row]:
+        with self._connect(slug) as conn:
+            return list(
+                conn.execute(
+                    "SELECT * FROM style_rules ORDER BY updated_at DESC, id DESC LIMIT ?",
+                    (max(1, int(limit)),),
+                )
+            )
+
+    def upsert_style_rule(
+        self,
+        slug: str,
+        *,
+        rule_key: str,
+        value: Any,
+    ) -> Tuple[int, bool]:
+        key = str(rule_key or "").strip()
+        if not key:
+            raise ValueError("rule_key is required")
+        payload: Dict[str, Any]
+        if isinstance(value, dict):
+            payload = dict(value)
+        elif isinstance(value, str):
+            payload = {"instruction": value}
+        else:
+            payload = {"value": value}
+        now = _now_ts()
+        value_json = self._json_dumps(payload)
+        with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT id, value_json FROM style_rules WHERE rule_key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                cur = conn.execute(
+                    """
+                    INSERT INTO style_rules(rule_key, value_json, created_at, updated_at)
+                    VALUES(?, ?, ?, ?)
+                    """,
+                    (key, value_json, now, now),
+                )
+                rule_id = int(cur.lastrowid)
+                self._log_change(
+                    conn,
+                    entity_type="style_rule",
+                    entity_key=key,
+                    action="create",
+                    payload={"rule_id": rule_id, "value": payload},
+                )
+                conn.commit()
+                return rule_id, True
+            rule_id = int(row["id"])
+            conn.execute(
+                "UPDATE style_rules SET value_json = ?, updated_at = ? WHERE id = ?",
+                (value_json, now, rule_id),
+            )
+            old_payload = self._json_loads(str(row["value_json"] or "{}"), {})
+            self._log_change(
+                conn,
+                entity_type="style_rule",
+                entity_key=key,
+                action="update",
+                payload={"rule_id": rule_id, "before": old_payload, "after": payload},
+            )
+            conn.commit()
+            return rule_id, False
+
+    def delete_style_rule(self, slug: str, rule_id: int) -> bool:
+        rid = int(rule_id)
+        with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT rule_key, value_json FROM style_rules WHERE id = ?",
+                (rid,),
+            ).fetchone()
+            if row is None:
+                return False
+            cur = conn.execute("DELETE FROM style_rules WHERE id = ?", (rid,))
+            if int(cur.rowcount or 0) > 0:
+                self._log_change(
+                    conn,
+                    entity_type="style_rule",
+                    entity_key=str(row["rule_key"] or ""),
+                    action="delete",
+                    payload={
+                        "rule_id": rid,
+                        "value": self._json_loads(str(row["value_json"] or "{}"), {}),
+                    },
+                )
+                conn.commit()
+                return True
+            conn.commit()
+            return False
+
+    @staticmethod
+    def _normalize_lore_status(status: str) -> str:
+        raw = str(status or "").strip().lower()
+        if raw in {"published", "active", "approved"}:
+            return "active"
+        if raw in {"archived", "inactive"}:
+            return "archived"
+        return "draft"
+
+    def list_lore_entries(
+        self,
+        slug: str,
+        *,
+        status: Optional[str] = None,
+        limit: int = 500,
+    ) -> List[sqlite3.Row]:
+        with self._connect(slug) as conn:
+            if status is None:
+                return list(
+                    conn.execute(
+                        "SELECT * FROM lore_entries ORDER BY updated_at DESC, id DESC LIMIT ?",
+                        (max(1, int(limit)),),
+                    )
+                )
+            return list(
+                conn.execute(
+                    "SELECT * FROM lore_entries WHERE status = ? ORDER BY updated_at DESC, id DESC LIMIT ?",
+                    (self._normalize_lore_status(status), max(1, int(limit))),
+                )
+            )
+
+    def upsert_lore_entry(
+        self,
+        slug: str,
+        *,
+        entry_key: str,
+        title: str,
+        content: str,
+        tags: Optional[Sequence[str]] = None,
+        status: str = "draft",
+    ) -> Tuple[int, bool]:
+        clean_title = str(title or "").strip()
+        clean_content = str(content or "").strip()
+        if not clean_title:
+            raise ValueError("title is required")
+        if not clean_content:
+            raise ValueError("content is required")
+        key = slugify(str(entry_key or "").strip() or clean_title)
+        clean_tags = sorted(
+            {
+                str(tag).strip()
+                for tag in (tags or [])
+                if str(tag).strip()
+            }
+        )
+        tags_json = self._json_dumps(clean_tags)
+        final_status = self._normalize_lore_status(status)
+        now = _now_ts()
+        with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT id, title, content, tags_json, status FROM lore_entries WHERE entry_key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                cur = conn.execute(
+                    """
+                    INSERT INTO lore_entries(entry_key, title, content, tags_json, status, created_at, updated_at)
+                    VALUES(?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (key, clean_title, clean_content, tags_json, final_status, now, now),
+                )
+                lore_id = int(cur.lastrowid)
+                self._log_change(
+                    conn,
+                    entity_type="lore",
+                    entity_key=key,
+                    action="create",
+                    payload={
+                        "lore_id": lore_id,
+                        "title": clean_title,
+                        "status": final_status,
+                        "tags": clean_tags,
+                    },
+                )
+                conn.commit()
+                return lore_id, True
+
+            lore_id = int(row["id"])
+            before = {
+                "title": str(row["title"] or ""),
+                "content": str(row["content"] or ""),
+                "status": str(row["status"] or ""),
+                "tags": self._json_loads(str(row["tags_json"] or "[]"), []),
+            }
+            conn.execute(
+                """
+                UPDATE lore_entries
+                SET title = ?, content = ?, tags_json = ?, status = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (clean_title, clean_content, tags_json, final_status, now, lore_id),
+            )
+            self._log_change(
+                conn,
+                entity_type="lore",
+                entity_key=key,
+                action="update",
+                payload={
+                    "lore_id": lore_id,
+                    "before": before,
+                    "after": {
+                        "title": clean_title,
+                        "content": clean_content,
+                        "status": final_status,
+                        "tags": clean_tags,
+                    },
+                },
+            )
+            conn.commit()
+            return lore_id, False
+
+    def set_lore_status(self, slug: str, lore_id: int, status: str) -> None:
+        lid = int(lore_id)
+        final_status = self._normalize_lore_status(status)
+        with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT entry_key, status FROM lore_entries WHERE id = ?",
+                (lid,),
+            ).fetchone()
+            if row is None:
+                return
+            conn.execute(
+                "UPDATE lore_entries SET status = ?, updated_at = ? WHERE id = ?",
+                (final_status, _now_ts(), lid),
+            )
+            self._log_change(
+                conn,
+                entity_type="lore",
+                entity_key=str(row["entry_key"] or ""),
+                action="status",
+                payload={
+                    "lore_id": lid,
+                    "before_status": str(row["status"] or ""),
+                    "status": final_status,
+                },
+            )
+            conn.commit()
+
+    def delete_lore_entry(self, slug: str, lore_id: int) -> bool:
+        lid = int(lore_id)
+        with self._connect(slug) as conn:
+            row = conn.execute(
+                "SELECT entry_key, title, content, tags_json, status FROM lore_entries WHERE id = ?",
+                (lid,),
+            ).fetchone()
+            if row is None:
+                return False
+            cur = conn.execute("DELETE FROM lore_entries WHERE id = ?", (lid,))
+            deleted = int(cur.rowcount or 0) > 0
+            if deleted:
+                self._log_change(
+                    conn,
+                    entity_type="lore",
+                    entity_key=str(row["entry_key"] or ""),
+                    action="delete",
+                    payload={
+                        "lore_id": lid,
+                        "title": str(row["title"] or ""),
+                        "status": str(row["status"] or ""),
+                        "tags": self._json_loads(str(row["tags_json"] or "[]"), []),
+                    },
+                )
+            conn.commit()
+            return deleted
+
+    def list_change_log(
+        self,
+        slug: str,
+        *,
+        entity_type: Optional[str] = None,
+        limit: int = 200,
+    ) -> List[sqlite3.Row]:
+        with self._connect(slug) as conn:
+            if entity_type is None:
+                return list(
+                    conn.execute(
+                        "SELECT * FROM change_log ORDER BY id DESC LIMIT ?",
+                        (max(1, int(limit)),),
+                    )
+                )
+            return list(
+                conn.execute(
+                    "SELECT * FROM change_log WHERE entity_type = ? ORDER BY id DESC LIMIT ?",
+                    (str(entity_type).strip(), max(1, int(limit))),
+                )
+            )
+
+    def export_series_profile(self, slug: str, *, output_path: Optional[Path] = None) -> Path:
+        clean_slug = slugify(slug)
+        terms = [
+            {"source_term": src, "target_term": dst}
+            for src, dst in self.list_approved_terms(clean_slug, limit=10000)
+        ]
+        style_rules: List[Dict[str, Any]] = []
+        for row in self.list_style_rules(clean_slug, limit=2000):
+            style_rules.append(
+                {
+                    "rule_key": str(row["rule_key"] or ""),
+                    "value": self._json_loads(str(row["value_json"] or "{}"), {}),
+                    "updated_at": int(row["updated_at"] or 0),
+                }
+            )
+        lore_entries: List[Dict[str, Any]] = []
+        for row in self.list_lore_entries(clean_slug, limit=5000):
+            lore_entries.append(
+                {
+                    "entry_key": str(row["entry_key"] or ""),
+                    "title": str(row["title"] or ""),
+                    "content": str(row["content"] or ""),
+                    "status": str(row["status"] or "draft"),
+                    "tags": self._json_loads(str(row["tags_json"] or "[]"), []),
+                    "updated_at": int(row["updated_at"] or 0),
+                }
+            )
+        payload = {
+            "schema_version": 1,
+            "series_slug": clean_slug,
+            "generated_at": _now_ts(),
+            "terms": terms,
+            "style_rules": style_rules,
+            "lore_entries": lore_entries,
+        }
+        out = output_path or (self.series_dir(clean_slug) / GENERATED_DIR / SERIES_PROFILE_FILE)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return out
+
+    def import_series_profile(self, slug: str, profile_path: Path) -> Dict[str, int]:
+        p = Path(profile_path)
+        if not p.exists():
+            raise FileNotFoundError(str(p))
+        raw = self._json_loads(p.read_text(encoding="utf-8", errors="replace"), {})
+        if not isinstance(raw, dict):
+            raise ValueError("Invalid series profile JSON")
+
+        style_added = 0
+        lore_added = 0
+        terms_added = 0
+
+        for row in raw.get("style_rules", []) or []:
+            if not isinstance(row, dict):
+                continue
+            key = str(row.get("rule_key", "")).strip()
+            if not key:
+                continue
+            _, created = self.upsert_style_rule(slug, rule_key=key, value=row.get("value", {}))
+            if created:
+                style_added += 1
+
+        for row in raw.get("lore_entries", []) or []:
+            if not isinstance(row, dict):
+                continue
+            key = str(row.get("entry_key", "")).strip() or slugify(str(row.get("title", "")))
+            title = str(row.get("title", "")).strip()
+            content = str(row.get("content", "")).strip()
+            if not title or not content:
+                continue
+            _, created = self.upsert_lore_entry(
+                slug,
+                entry_key=key,
+                title=title,
+                content=content,
+                tags=[str(x) for x in (row.get("tags", []) or []) if str(x).strip()],
+                status=str(row.get("status", "draft")),
+            )
+            if created:
+                lore_added += 1
+
+        for row in raw.get("terms", []) or []:
+            if not isinstance(row, dict):
+                continue
+            src = str(row.get("source_term", "")).strip()
+            dst = str(row.get("target_term", "")).strip()
+            if not src or not dst:
+                continue
+            _, created = self.add_or_update_term(
+                slug,
+                source_term=src,
+                target_term=dst,
+                status="approved",
+                confidence=1.0,
+                origin="series-profile-import",
+            )
+            if created:
+                terms_added += 1
+
+        return {
+            "style_added": style_added,
+            "lore_added": lore_added,
+            "terms_added": terms_added,
+        }
+
+    def build_series_context_block(
+        self,
+        slug: str,
+        *,
+        max_rules: int = 24,
+        max_lore: int = 24,
+        max_terms: int = 80,
+        max_chars: int = 8000,
+    ) -> str:
+        clean_slug = slugify(slug)
+        out: List[str] = []
+        used = 0
+
+        def _append(line: str) -> None:
+            nonlocal used
+            if used >= max_chars:
+                return
+            part = str(line or "")
+            if not part:
+                return
+            budget = max_chars - used
+            if len(part) > budget:
+                part = part[: max(0, budget - 3)] + "..."
+            out.append(part)
+            used += len(part) + 1
+
+        style_rows = self.list_style_rules(clean_slug, limit=max_rules)
+        lore_rows = self.list_lore_entries(clean_slug, status="active", limit=max_lore)
+        term_rows = self.list_approved_terms(clean_slug, limit=max_terms)
+
+        if style_rows:
+            _append("Style rules (series-level):")
+            for row in style_rows:
+                data = self._json_loads(str(row["value_json"] or "{}"), {})
+                if isinstance(data, dict):
+                    text = str(data.get("instruction") or data.get("value") or data.get("text") or "").strip()
+                    if not text:
+                        text = self._json_dumps(data)
+                else:
+                    text = str(data).strip()
+                _append(f"- {str(row['rule_key'] or '').strip()}: {text}")
+
+        if lore_rows:
+            if out:
+                _append("")
+            _append("Lorebook (active facts):")
+            for row in lore_rows:
+                tags = self._json_loads(str(row["tags_json"] or "[]"), [])
+                tags_text = ""
+                if isinstance(tags, list):
+                    clean_tags = [str(t).strip() for t in tags if str(t).strip()]
+                    if clean_tags:
+                        tags_text = f" [tags: {', '.join(clean_tags)}]"
+                title = str(row["title"] or "").strip()
+                content = str(row["content"] or "").strip().replace("\n", " ")
+                _append(f"- {title}: {content}{tags_text}")
+
+        if term_rows:
+            if out:
+                _append("")
+            _append("Terminology (approved):")
+            for src, dst in term_rows:
+                _append(f"- {src} => {dst}")
+
+        return "\n".join(out).strip()
+
+    def build_augmented_prompt(
+        self,
+        slug: str,
+        *,
+        base_prompt_path: Path,
+        output_path: Path,
+        run_step: str = "translate",
+    ) -> Path:
+        base = Path(base_prompt_path)
+        if not base.exists():
+            raise FileNotFoundError(str(base))
+        context = self.build_series_context_block(slug)
+        base_prompt = base.read_text(encoding="utf-8", errors="replace")
+        if not context:
+            final = base_prompt
+        else:
+            final = (
+                base_prompt.rstrip()
+                + "\n\n"
+                + "### SERIES MEMORY CONTEXT (DO NOT TRANSLATE THIS BLOCK)\n"
+                + f"Run step: {str(run_step or 'translate').strip()}\n"
+                + context
+                + "\n### END OF SERIES MEMORY CONTEXT\n"
+            )
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(final + ("\n" if final and not final.endswith("\n") else ""), encoding="utf-8")
+        return out
 
     def add_decision(
         self,

--- a/project-tkinter/studio_repository.py
+++ b/project-tkinter/studio_repository.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+from project_db import ProjectDB
+
+
+class StudioRepository(Protocol):
+    def list_projects_with_stage_summary(self) -> List[Dict[str, Any]]: ...
+    def list_projects_for_series(self, series_id: int, *, include_deleted: bool = False) -> List[Dict[str, Any]]: ...
+    def mark_project_pending(self, project_id: int, step: str) -> None: ...
+    def get_next_pending_project(self) -> Optional[Dict[str, Any]]: ...
+    def get_project(self, project_id: int) -> Optional[Dict[str, Any]]: ...
+    def get_series(self, series_id: int) -> Optional[Dict[str, Any]]: ...
+    def count_open_qa_findings(self, project_id: int) -> int: ...
+
+
+class SQLiteStudioRepository:
+    """SQLite-backed repository adapter for queue/batch workflows.
+
+    This keeps GUI orchestration separate from storage implementation details.
+    """
+
+    def __init__(self, db: ProjectDB):
+        self.db = db
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> Optional[Dict[str, Any]]:
+        if row is None:
+            return None
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return dict(row)
+        except Exception:
+            return None
+
+    def list_projects_with_stage_summary(self) -> List[Dict[str, Any]]:
+        return [dict(r) for r in self.db.list_projects_with_stage_summary()]
+
+    def list_projects_for_series(self, series_id: int, *, include_deleted: bool = False) -> List[Dict[str, Any]]:
+        return [dict(r) for r in self.db.list_projects_for_series(series_id, include_deleted=include_deleted)]
+
+    def mark_project_pending(self, project_id: int, step: str) -> None:
+        self.db.mark_project_pending(int(project_id), str(step))
+
+    def get_next_pending_project(self) -> Optional[Dict[str, Any]]:
+        return self._row_to_dict(self.db.get_next_pending_project())
+
+    def get_project(self, project_id: int) -> Optional[Dict[str, Any]]:
+        return self._row_to_dict(self.db.get_project(int(project_id)))
+
+    def get_series(self, series_id: int) -> Optional[Dict[str, Any]]:
+        return self._row_to_dict(self.db.get_series(int(series_id)))
+
+    def count_open_qa_findings(self, project_id: int) -> int:
+        row = self.db.conn.execute(
+            "SELECT COUNT(*) AS c FROM qa_findings WHERE project_id = ? AND status = 'open'",
+            (int(project_id),),
+        ).fetchone()
+        return int(row["c"] or 0) if row else 0

--- a/project-tkinter/tests/test_repository_layer.py
+++ b/project-tkinter/tests/test_repository_layer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from project_db import ProjectDB, SCHEMA_META_ALIAS_KEY, SCHEMA_META_KEY  # noqa: E402
+from studio_repository import SQLiteStudioRepository  # noqa: E402
+
+
+def test_schema_version_alias_is_set_for_new_db(tmp_path: Path) -> None:
+    db = ProjectDB(tmp_path / "studio.db")
+    try:
+        raw_schema = db._meta_get(SCHEMA_META_KEY)  # noqa: SLF001
+        raw_alias = db._meta_get(SCHEMA_META_ALIAS_KEY)  # noqa: SLF001
+        assert raw_schema is not None
+        assert raw_alias is not None
+        assert str(raw_schema) == str(raw_alias)
+    finally:
+        db.close()
+
+
+def test_schema_version_alias_recovers_legacy_alias_only_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy_alias.db"
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    raw.execute(
+        "INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)",
+        (SCHEMA_META_ALIAS_KEY, "8"),
+    )
+    raw.commit()
+    raw.close()
+
+    db = ProjectDB(db_path, run_migrations=False)
+    try:
+        assert db._schema_version() == 8  # noqa: SLF001
+        assert str(db._meta_get(SCHEMA_META_KEY)) == "8"  # noqa: SLF001
+        assert str(db._meta_get(SCHEMA_META_ALIAS_KEY)) == "8"  # noqa: SLF001
+    finally:
+        db.close()
+
+
+def test_sqlite_repository_queue_and_qa_counts(tmp_path: Path) -> None:
+    db = ProjectDB(tmp_path / "studio.db")
+    repo = SQLiteStudioRepository(db)
+    try:
+        sid = db.ensure_series("Repo Saga", source="manual")
+        pid = db.create_project(
+            "Repo Book 1",
+            {
+                "series_id": sid,
+                "volume_no": 1.0,
+                "input_epub": str(tmp_path / "book.epub"),
+                "output_translate_epub": str(tmp_path / "book_pl.epub"),
+                "output_edit_epub": str(tmp_path / "book_pl_edit.epub"),
+            },
+        )
+
+        series_projects = repo.list_projects_for_series(sid)
+        assert len(series_projects) == 1
+        assert int(series_projects[0]["id"]) == pid
+
+        repo.mark_project_pending(pid, "translate")
+        nxt = repo.get_next_pending_project()
+        assert nxt is not None
+        assert int(nxt["id"]) == pid
+
+        assert repo.count_open_qa_findings(pid) == 0
+        inserted = db.replace_qa_findings(
+            project_id=pid,
+            step="translate",
+            findings=[
+                {
+                    "chapter_path": "OPS/ch1.xhtml",
+                    "segment_index": 1,
+                    "segment_id": "OPS/ch1.xhtml#1",
+                    "severity": "error",
+                    "rule_code": "TEST",
+                    "message": "example",
+                }
+            ],
+        )
+        assert inserted == 1
+        assert repo.count_open_qa_findings(pid) == 1
+    finally:
+        db.close()


### PR DESCRIPTION
## Opis zmian

- Domknieto M7: pelny Series Manager (termy, style rules, lorebook, historia zmian) oraz orchestrator batch serii z raportami series_batch_report_*.json/.md.
- Dodano warstwe Repository (project-tkinter/studio_repository.py) i przepieto pod nia krytyczne workflow queue/batch w GUI.
- Dodano alias metadanych bazy db_version synchronizowany z schema_version (odczyt, naprawa aliasu, migracje).
- Zaktualizowano README (EN/PL): sekcje unikalne cechy oraz standardowe cechy projektu.
- Zaktualizowano dokumentacje roadmap/backlog/manual i podniesiono runtime do 0.6.0.

## Powod zmiany

- Celem bylo domkniecie M7 jako publikowalnego incrementu: spojna pamiec serii i realna praca wsadowa dla wielu tomow.
- Alias db_version poprawia kompatybilnosc metadanych wersji bazy bez dublowania silnika migracji.
- Repository step to future-proof: GUI orchestration jest mniej zwiazane ze szczegolami SQLite i latwiej je przeniesc na inny backend.

## Zakres

- [x] backend
- [x] desktop/frontend
- [x] dokumentacja
- [x] CI/CD
- [x] refactor
- [x] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji
- Lokalnie uruchomiono:
- python -m py_compile project-tkinter/project_db.py project-tkinter/studio_repository.py project-tkinter/app_gui_classic.py
- pytest -q (caly project-tkinter) -> 41 passed

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [ ] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
