### PR TITLE
Docs: close M3 after wiki backend activation

### DIFF
--- a/docs/07-Roadmapa-i-kontrybucje.md
+++ b/docs/07-Roadmapa-i-kontrybucje.md
@@ -4,7 +4,7 @@
 
 - `M1`: zrealizowane.
 - `M2`: zrealizowane.
-- `M3`: zamrozone (blokada po stronie GitHub Wiki; bez wpływu na runtime aplikacji).
+- `M3`: zrealizowane (Wiki backend aktywny, opublikowane: `Home`, `_Sidebar`, `Workflow-and-Recovery`).
 - `M7`: domkniete (series manager: termy + style rules + lorebook + historia zmian, prompt augmentation kontekstem serii, orchestrator batch serii z raportem).
 - `M4`: domkniete (ledger orchestration upfront + twardy gate EPUBCheck + tokenized inline editor + dashboard ledger metrics + stale widoczny pasek ledgera + presety promptow Gemini w GUI + telemetry retry/timeout + export metryk do release notes + alert progowy ledgera).
 - `M5`: domkniete (nested-inline chips w edytorze + dodatkowe testy regresji + walidator integralnosci `&shy;/&nbsp;` z raportem po runie).
@@ -74,11 +74,12 @@ Jesli projekt oszczedza czas:
 - mniejsza liczba problemow z konfiguracja,
 - szybszy onboarding nowego urzadzenia.
 
-## 7.8. Kolejne milestone'y (po M1-M2, M3 zamrozone, M4-M7 domkniete)
+## 7.8. Kolejne milestone'y (po M1-M2, M3-M7 domkniete)
 
 1. Stabilizacja i utrzymanie M4-M7 (bugfixy + ergonomia).
-2. Odmrozenie `M3 / Wiki` po odblokowaniu backendu GitHub Wiki.
+2. Utrzymanie dokumentacji Wiki i synchronizacji z `docs/wiki`.
 3. Kolejny increment funkcjonalny po uzgodnieniu backlogu.
 
 Zakres i kryteria `Done` sa utrzymywane w:
 - `docs/09-Backlog-do-uzgodnienia.md`
+

--- a/docs/09-Backlog-do-uzgodnienia.md
+++ b/docs/09-Backlog-do-uzgodnienia.md
@@ -3,7 +3,7 @@
 Status:
 - `M1 wdrozone` w kodzie i dokumentacji (2026-02-08),
 - `M2 wdrozone` w kodzie i CI (2026-02-08),
-- `M3 zamrozone`: blokada po stronie GitHub Wiki backend (Issue 7 odlozone),
+- `M3 zrealizowane`: Wiki backend aktywny, opublikowane strony `Home`, `_Sidebar`, `Workflow-and-Recovery` (Issue 7 domkniete),
 - `M4 domkniete`: memory-first translation (cache + decision memory + adaptive prompting), z domknietymi metrykami ledgera/retry/timeout i eksportem release notes,
 - `M5 zrealizowane`: EPUB-aware segmentacja i integralnosc markup (`&shy;`, inline tags),
 - `M6 zrealizowane`: diff-aware retranslation + semantic diff gate do recenzji,
@@ -15,7 +15,7 @@ Zamienic roadmape na konkretne, mierzalne zadania z jasnym zakresem i kryteriami
 
 ## Aktywne milestone'y
 
-1. `M3: Workflow + Docs + Wiki (zamrozone)`
+1. `M3: Workflow + Docs + Wiki`
 2. Utrzymanie i stabilizacja M4-M7
 
 ## M1: UI Consistency + UX Telemetry
@@ -76,7 +76,7 @@ Status M2: `zrealizowane`.
 
 ## M3: Workflow + Docs + Wiki
 
-Status M3: `zamrozone` (2/3 issue zamkniete, blokada zewnetrzna po stronie GitHub Wiki backend).
+Status M3: `zrealizowane` (3/3 issue zamkniete).
 
 ### Issue 7: Inicjalizacja i utrzymanie Wiki
 - Zakres:
@@ -86,12 +86,12 @@ Status M3: `zamrozone` (2/3 issue zamkniete, blokada zewnetrzna po stronie GitHu
   - `/wiki` dziala bez przekierowania na strone repo,
   - wiki ma minimum 1 strone i sidebar.
 
-Status: `zamrozone` (backend Wiki wymaga inicjalizacji pierwszej strony `Home` przez UI GitHub).
+Status: `zrealizowane` (Wiki backend aktywny i zsynchronizowany skryptem publikacji).
 
 Postep:
-- gotowy pakiet stron wiki w repo: `docs/wiki/Home.md`, `docs/wiki/_Sidebar.md`, `docs/wiki/Workflow-and-Recovery.md`,
-- gotowy skrypt publikacji: `project-tkinter/scripts/publish_wiki.ps1`,
-- po jednorazowej inicjalizacji backendu Wiki (klik w UI) publikacja idzie automatycznie skryptem.
+- pakiet stron wiki opublikowany: `Home`, `_Sidebar`, `Workflow-and-Recovery`,
+- backend Wiki aktywny (`epub-translator-studio.wiki.git`),
+- publikacja wykonywana skryptem `project-tkinter/scripts/publish_wiki.ps1`.
 
 ### Issue 8: Release checklist i changelog discipline
 - Zakres:
@@ -267,7 +267,7 @@ Status:
 
 1. `M4` utrzymanie i stabilizacja po wdrozeniu.
 2. `M7` utrzymanie i ergonomia po wdrozeniu.
-3. `M3 / Issue 7` (Wiki backend + Home + sidebar) dopiero po odmrozeniu.
+3. Utrzymanie M3 (regularna synchronizacja `docs/wiki` -> Wiki).
 
 ## Definicja publikacji milestone
 


### PR DESCRIPTION
## Opis zmian

- Potwierdzono aktywacje backendu GitHub Wiki (`epub-translator-studio.wiki.git`) i opublikowano strony: `Home`, `_Sidebar`, `Workflow-and-Recovery`.
- Zaktualizowano statusy roadmapy/backlogu: `M3` przestaje byc zamrozone i jest oznaczone jako zrealizowane.
- Ujednolicono plan dalszych prac: M3 przechodzi do utrzymania (synchronizacja `docs/wiki` -> Wiki).

## Powod zmiany

- Stan techniczny i dokumentacyjny byl niespojny: Wiki juz dzialala, ale backlog nadal pokazywal blokade zewnetrzna.
- Celem jest zgodnosc roadmapy z realnym stanem repo i publikacji.
- To zamyka formalnie M3 i upraszcza planowanie kolejnych incrementow.

## Zakres

- [ ] backend
- [ ] desktop/frontend
- [x] dokumentacja
- [ ] CI/CD
- [ ] refactor
- [x] bugfix

## Jak testowano

- [x] test lokalny
- [x] brak regresji krytycznych sciezek
- [x] dokumentacja zaktualizowana (jesli potrzeba)
- [x] dodano kroki uruchomienia lub reprodukcji
- Weryfikacja techniczna Wiki:
- `git ls-remote https://github.com/Piotr-Grechuta/epub-translator-studio.wiki.git`
- `project-tkinter/scripts/publish_wiki.ps1` (push na wiki master)

## Lista kontrolna

- [x] Kod jest czytelny i utrzymywalny
- [x] Zmiana nie lamie aktualnego workflow
- [ ] Jesli dodano funkcje, dodano tez krotki opis uzycia
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji)
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje bez placeholderow (np. TODO, <uzupelnij>)
