### PR TITLE
[M9] Easy Mode: one-screen guided flow with provider preflight

### DIFF
--- a/project-tkinter/app_gui_horizon.py
+++ b/project-tkinter/app_gui_horizon.py
@@ -38,16 +38,19 @@ class HorizonGUI(base.TranslatorGUI):
         tabs = ttk.Notebook(tabs_wrap)
         tabs.pack(fill="both", expand=True)
 
+        easy_tab = ttk.Frame(tabs, padding=8)
         files_tab = ttk.Frame(tabs, padding=8)
         engine_tab = ttk.Frame(tabs, padding=8)
         log_tab = ttk.Frame(tabs, padding=8)
         layout_tab = ttk.Frame(tabs, padding=8)
 
+        tabs.add(easy_tab, text="Easy Mode")
         tabs.add(files_tab, text="Pliki i Tryb")
         tabs.add(engine_tab, text="Silnik i Model")
         tabs.add(log_tab, text="Log")
         tabs.add(layout_tab, text="Układanie EPUB")
 
+        self._build_easy_mode_card(easy_tab)
         self._build_project_card(files_tab)
         self._build_files_card(files_tab)
         self._build_run_card(files_tab)


### PR DESCRIPTION
﻿## Opis zmian
- Dodano Easy Mode jako jednowidokowy flow w `app_gui_classic.py` oraz zakladke Easy Mode w `app_gui_horizon.py`.
- Uzytkownik wybiera tylko: plik EPUB, jezyk zrodlowy/docelowy, model tlumacza, model redaktora oraz katalog wyjsciowy.
- Dodano preflight providera przed startem runu (Google API key, Ollama health + opcjonalny auto-start).
- Dodano dual progress dla Easy Mode: globalny progress + liczniki translate/edit + aktualna faza.
- Dodano tryby wykonania: `streaming`, `parallel`, `translate-only`, `edit-only` i ich integracje z istniejacym flow uruchomien.
- Dodano persystencje ustawien Easy Mode w `ui_state`.
- Rozszerzono testy reliability o walidacje planu trybow, preflight i agregacji postepu.

## Powod zmiany
Issue #51 wymaga prostego, bezpiecznego wejscia dla uzytkownika nietechnicznego bez przechodzenia przez zaawansowane konfiguracje. Ta zmiana zachowuje obecny silnik i ledger, ale upraszcza UX do jednego ekranu i dodaje twardy preflight providera przed startem.

## Jak testowano
- [x] `python -m py_compile project-tkinter/runtime_core.py project-tkinter/app_gui_classic.py project-tkinter/app_gui_horizon.py project-tkinter/tests/test_reliability_features.py`
- [x] `pytest -p no:cacheprovider project-tkinter/tests/test_reliability_features.py`
- [x] `pytest -p no:cacheprovider project-tkinter/tests`
- [x] Manualny smoke-test flowu Easy Mode (start translate/edit z preflight i aktualizacja progressu) na lokalnym GUI.

## Lista kontrolna
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje opisu PR.
- [x] Jesli dodano funkcje, dodano tez krotki opis uzycia.
- [ ] Nie dotyczy (ta zmiana nie dodaje nowych funkcji).

Closes #51
