### PR TITLE
Fix Windows UTF-8 and Polish prompt mojibake in batch flow

### DIFF
--- a/project-tkinter/app_gui_classic.py
+++ b/project-tkinter/app_gui_classic.py
@@ -4342,7 +4342,12 @@ class TranslatorGUI:
             runner_db: Optional[ProjectDB] = None
             try:
                 runner_db = ProjectDB(SQLITE_FILE)
-                env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+                env = {
+                    **os.environ,
+                    "PYTHONUNBUFFERED": "1",
+                    "PYTHONIOENCODING": "utf-8",
+                    "PYTHONUTF8": "1",
+                }
                 if provider == "google":
                     if google_api_key:
                         env[GOOGLE_API_KEY_ENV] = google_api_key
@@ -4530,7 +4535,12 @@ class TranslatorGUI:
                 self.proc = subprocess.Popen(
                     cmd,
                     cwd=str(self.workdir),
-                    env={**os.environ, "PYTHONUNBUFFERED": "1"},
+                    env={
+                        **os.environ,
+                        "PYTHONUNBUFFERED": "1",
+                        "PYTHONIOENCODING": "utf-8",
+                        "PYTHONUTF8": "1",
+                    },
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,

--- a/project-tkinter/app_gui_classic.py
+++ b/project-tkinter/app_gui_classic.py
@@ -78,7 +78,7 @@ GOOGLE_KEYRING_USER = "google_api_key"
 EPUBCHECK_TIMEOUT_S = 120
 APP_RUNTIME_VERSION = "0.6.1"
 GLOBAL_PROGRESS_RE = re.compile(r"GLOBAL\s+(\d+)\s*/\s*(\d+)\s*\(([^)]*)\)\s*\|\s*(.*)")
-TOTAL_SEGMENTS_RE = re.compile(r"Segmenty\s+(?:Äąâ€šĂ„â€¦cznie|lacznie)\s*:\s*(\d+)", re.IGNORECASE)
+TOTAL_SEGMENTS_RE = re.compile(r"Segmenty\s+(?:łącznie|lacznie)\s*:\s*(\d+)", re.IGNORECASE)
 CACHE_SEGMENTS_RE = re.compile(r"Segmenty\s+z\s+cache\s*:\s*(\d+)", re.IGNORECASE)
 CHAPTER_CACHE_TM_RE = re.compile(r"\(cache:\s*(\d+)\s*,\s*tm:\s*(\d+)\)", re.IGNORECASE)
 METRICS_BLOB_RE = re.compile(r"metrics\[(.*?)\]", re.IGNORECASE)
@@ -1283,7 +1283,7 @@ class TranslatorGUI:
         self._row_file(card, 1, self.tr("file.input_epub", "WejÄąâ€şciowy EPUB"), self.input_epub_var, [("EPUB", "*.epub")], self._on_input_selected)
         self._row_file(card, 2, self.tr("file.output_epub", "WyjÄąâ€şciowy EPUB"), self.output_epub_var, [("EPUB", "*.epub")])
         self._row_file(card, 3, self.tr("file.prompt", "Prompt"), self.prompt_var, [("TXT", "*.txt")], self._on_prompt_changed)
-        self._row_file(card, 4, self.tr("file.glossary", "SÄąâ€šownik"), self.glossary_var, [("TXT", "*.txt")])
+        self._row_file(card, 4, self.tr("file.glossary", "Słownik"), self.glossary_var, [("TXT", "*.txt")])
         self._row_file(card, 5, self.tr("file.cache", "Cache"), self.cache_var, [("JSONL", "*.jsonl"), ("All", "*.*")])
 
         ttk.Label(card, text=self.tr("label.mode", "Tryb:")).grid(row=6, column=0, sticky="w", pady=(8, 0))
@@ -3556,11 +3556,17 @@ class TranslatorGUI:
         return [py, "-u", self.translator_path.name]
 
     def _find_glossary(self, workdir: Path) -> Optional[Path]:
-        for name in ["SLOWNIK.txt", "slownik.txt", "Slownik.txt", "SÄąâ€šownik.txt", "SÄąÂOWNIK.txt"]:
+        for name in ["SLOWNIK.txt", "slownik.txt", "Slownik.txt", "SŁOWNIK.txt", "Słownik.txt", "słownik.txt"]:
             p = workdir / name
             if p.exists():
                 return p
-        cands = sorted([p for p in workdir.glob("*.txt") if "slownik" in p.name.lower() or "sÄąâ€šownik" in p.name.lower()])
+        cands = sorted(
+            [
+                p
+                for p in workdir.glob("*.txt")
+                if "slownik" in p.name.lower() or "słownik" in p.name.lower()
+            ]
+        )
         return cands[0] if cands else None
 
     def _on_input_selected(self) -> None:

--- a/project-tkinter/translation_engine.py
+++ b/project-tkinter/translation_engine.py
@@ -983,7 +983,7 @@ def sanitize_model_output(s: str) -> str:
     if out.startswith("```"):
         out = re.sub(r"^```[a-zA-Z0-9_-]*\s*", "", out)
         out = re.sub(r"\s*```$", "", out)
-    out = re.sub(r"^\s*(TĹ‚umaczenie|Translation)\s*:\s*", "", out, flags=re.IGNORECASE)
+    out = re.sub(r"^\s*(Tłumaczenie|Translation)\s*:\s*", "", out, flags=re.IGNORECASE)
     return out.strip()
 
 
@@ -1015,14 +1015,14 @@ def build_batch_prompt(
         )
     parts.append(
         "Zadanie:\n"
-        "PrzetĹ‚umacz na jÄ™zyk polski PONIĹ»SZY XML (XHTML).\n"
-        "WewnÄ…trz <seg> znajdujÄ… siÄ™ fragmenty (wnÄ™trza akapitĂłw). KaĹĽdy <seg> tĹ‚umacz jako caĹ‚oĹ›Ä‡.\n"
+        "Przetłumacz na język polski PONIŻSZY XML (XHTML).\n"
+        "Wewnątrz <seg> znajdują się fragmenty (wnętrza akapitów). Każdy <seg> tłumacz jako całość.\n"
         "Wymagania krytyczne:\n"
-        "- ZACHOWAJ DOKĹADNIE strukturÄ™ i tagi: <batch>, <seg id=\"...\"> oraz WSZYSTKIE tagi XHTML wewnÄ…trz.\n"
-        "- Nie zmieniaj ani nie usuwaj atrybutĂłw, w tym id w <seg>.\n"
-        "- Nie dodawaj ĹĽadnego komentarza/metatekstu.\n"
-        "- ZwrĂłÄ‡ WYĹÄ„CZNIE wynikowy XML <batch>...</batch>.\n"
-        "\nWEJĹšCIE:\n"
+        "- ZACHOWAJ DOKŁADNIE strukturę i tagi: <batch>, <seg id=\"...\"> oraz WSZYSTKIE tagi XHTML wewnątrz.\n"
+        "- Nie zmieniaj ani nie usuwaj atrybutów, w tym id w <seg>.\n"
+        "- Nie dodawaj żadnego komentarza/metatekstu.\n"
+        "- Zwróć WYŁĄCZNIE wynikowy XML <batch>...</batch>.\n"
+        "\nWEJŚCIE:\n"
         f"{batch_xml}\n"
     )
     return "\n\n".join(parts).strip() + "\n"
@@ -1156,7 +1156,7 @@ def build_language_instruction(source_lang: str, target_lang: str) -> str:
     return (
         "KRYTYCZNE: Tlumacz wiernie z jezyka "
         f"{src} na jezyk {tgt}. "
-        f"Wynik musi byc wyĹ‚Ä…cznie w jezyku {tgt}. "
+        f"Wynik musi byc wyłącznie w jezyku {tgt}. "
         "Zachowaj znaczniki XML i ich kolejnosc."
     )
 
@@ -1172,7 +1172,7 @@ def debug_dump(debug_dir: Optional[Path], prefix: str, prompt: str, response: st
 def parse_batch_response(xml_text: str) -> Dict[str, str]:
     raw = sanitize_model_output(xml_text).strip()
     if not raw:
-        raise RuntimeError("Pusta odpowiedĹş z modelu (response=='' po sanitize).")
+        raise RuntimeError("Pusta odpowiedź z modelu (response=='' po sanitize).")
 
     m = re.search(r"(<batch\b[\s\S]*?</batch>)", raw, flags=re.IGNORECASE)
     if m:
@@ -1182,12 +1182,12 @@ def parse_batch_response(xml_text: str) -> Dict[str, str]:
     parser = etree.XMLParser(recover=True, huge_tree=True)
     root = etree.fromstring(raw.encode("utf-8", errors="replace"), parser=parser)
     if root is None:
-        raise RuntimeError("Nie udaĹ‚o siÄ™ sparsowaÄ‡ odpowiedzi modelu jako XML (root=None).")
+        raise RuntimeError("Nie udało się sparsować odpowiedzi modelu jako XML (root=None).")
 
     if etree.QName(root).localname.lower() != "batch":
         batch = root.find(".//{*}batch")
         if batch is None:
-            raise RuntimeError("OdpowiedĹş nie zawiera elementu <batch>.")
+            raise RuntimeError("Odpowiedź nie zawiera elementu <batch>.")
         root = batch
 
     out: Dict[str, str] = {}
@@ -1198,7 +1198,7 @@ def parse_batch_response(xml_text: str) -> Dict[str, str]:
         out[sid] = inner_xml(seg)
 
     if not out:
-        raise RuntimeError("Nie znaleziono ĹĽadnych <seg id=...> w <batch>.")
+        raise RuntimeError("Nie znaleziono żadnych <seg id=...> w <batch>.")
     return out
 
 
@@ -2930,8 +2930,8 @@ def translate_epub(
     semantic_findings: List[Dict[str, Any]] = []
     quote_stats = QuoteNormalizationStats()
 
-    print("\n=== POSTÄP GLOBALNY (CAĹY EPUB) ===")
-    print(f"  Segmenty Ĺ‚Ä…cznie:     {global_total}")
+    print("\n=== POSTĘP GLOBALNY (CAŁY EPUB) ===")
+    print(f"  Segmenty łącznie:     {global_total}")
     print(f"  Segmenty z cache:     {global_cached}")
     if resume_extra_done > 0:
         print(f"  Segmenty z resume:    {resume_extra_done}")
@@ -2940,7 +2940,7 @@ def translate_epub(
         print(f"  Ledger upserted:     {ledger_seed.upserted_segments}")
         if ledger_seed.pruned_segments > 0:
             print(f"  Ledger pruned:       {ledger_seed.pruned_segments}")
-    print(f"  Segmenty do tĹ‚umacz.: {global_to_translate}")
+    print(f"  Segmenty do tłumacz.: {global_to_translate}")
     if global_total > 0:
         print(f"  Start progress:       {global_done}/{global_total} ({(global_done/global_total)*100:.1f}%)")
     print("===================================\n")


### PR DESCRIPTION
## Summary
- enforce UTF-8 subprocess environment in GUI runtime/validation launches
- set `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` alongside `PYTHONUNBUFFERED=1`
- repair mojibake in batch prompt/parsing text constants in `translation_engine.py` so dumped `*.request.txt` keeps proper Polish diacritics
- remove residual mojibake in `translation_engine.py` operational messages/comments/help text
- fix glossary auto-detection in `app_gui_classic.py` for `SŁOWNIK.txt` / `słownik.txt` and normalize glossary label fallback
- fix global progress regex to match `Segmenty łącznie` reliably

## Why
This removes corrupted Polish text paths, improves glossary detection in PL naming variants, and keeps request/prompt output readable and stable on Windows.

## Scope
- `project-tkinter/app_gui_classic.py`
- `project-tkinter/translation_engine.py`

## Verification
- `python -m py_compile project-tkinter/translation_engine.py project-tkinter/app_gui_classic.py`
- C1 control scan (`U+0080..U+009F`) in both files: `0` lines
- prompt generation still emits proper Polish diacritics in batch instruction text