### PR TITLE
chore(prompt): wzmocnij gate jakości tłumaczeń PL

### DIFF
--- a/project-tkinter/prompt.txt
+++ b/project-tkinter/prompt.txt
@@ -29,3 +29,16 @@ FORMAT WYJŚCIA (ABSOLUTNIE WYMAGANY)
 TRYB AWARYJNY (KRYTYCZNE)
 - Jeśli z jakiegokolwiek powodu nie potrafisz zwrócić poprawnego XML w wymaganym formacie:
   zwróć DOKŁADNIE wejściowy <batch> bez zmian (kopiuj 1:1).
+
+JAKOŚĆ JĘZYKOWA (KRYTYCZNE)
+- Wynik ma być naturalną, poprawną polszczyzną; unikaj kalk językowych i dosłownego szyku angielskiego.
+- Nie zostawiaj angielskich słów/fraz w treści segmentów (wyjątek: nazwy własne, terminy jawnie narzucone terminologią, cytaty kodu).
+- Jeśli zdanie brzmi nienaturalnie po tłumaczeniu dosłownym, popraw szyk i fleksję bez zmiany sensu.
+- W dialogach zachowuj naturalny rytm mowy i poprawną interpunkcję polską.
+
+SAMOKONTROLA PRZED ZWROTEM (WYKONAJ WEWNĘTRZNIE)
+1) Sprawdź każdy <seg>: sens zgodny z EN, brak pominięć, brak dopisków.
+2) Sprawdź każdy <seg>: brak nieprzetłumaczonych wstawek EN (poza dozwolonymi wyjątkami).
+3) Sprawdź spójność terminologii i nazw własnych w całym batchu.
+4) Sprawdź XML: ta sama liczba <seg>, te same id i kolejność, brak pustych segmentów.
+5) Dopiero potem zwróć finalny XML.

--- a/project-tkinter/translation_engine.py
+++ b/project-tkinter/translation_engine.py
@@ -1022,6 +1022,13 @@ def build_batch_prompt(
         "- Nie zmieniaj ani nie usuwaj atrybutów, w tym id w <seg>.\n"
         "- Nie dodawaj żadnego komentarza/metatekstu.\n"
         "- Zwróć WYŁĄCZNIE wynikowy XML <batch>...</batch>.\n"
+        "- Nie zostawiaj angielskich fraz/słów w segmentach (wyjątek: nazwy własne i terminy jawnie narzucone).\n"
+        "- Jeśli tłumaczenie dosłowne brzmi nienaturalnie po polsku, popraw szyk/fleksję bez zmiany sensu.\n"
+        "Samokontrola (wewnętrznie, przed odpowiedzią):\n"
+        "1) każdy <seg> ma sens zgodny z EN,\n"
+        "2) brak przypadkowych wstawek EN,\n"
+        "3) zachowana terminologia i nazwy własne,\n"
+        "4) ta sama liczba <seg>, te same id i kolejność, brak pustych <seg>.\n"
         "\nWEJŚCIE:\n"
         f"{batch_xml}\n"
     )


### PR DESCRIPTION
## Opis zmian
Wzmocniono quality gate dla promptow tlumaczeniowych PL. Zmiana porzadkuje i uszczelnia wymagania walidacyjne, aby ograniczyc bledy semantyczne i niespojnosci w segmentach.

## Powod zmiany
Celem jest podniesienie stabilnosci i jakosci procesu tlumaczenia wsadowego, szczegolnie dla kontroli 1:1, integralnosci XML oraz zgodnosci terminologii systemowej.

## Jak testowano
- [x] Zweryfikowano spojnosc promptu i brak placeholderow.
- [x] Sprawdzono, ze format wymagan i gate jest kompletny i jednoznaczny.
- [ ] Uruchomiono pelny run produkcyjny na zbiorze ksiazki.

## Lista kontrolna
- [x] Potwierdzam, ze uzupelnilem wszystkie sekcje.
- [x] Nie dotyczy (ta zmiana nie dodaje nowych funkcji).
- [x] Zmiana nie wymaga migracji danych.